### PR TITLE
feat: #32 FeedView에서 당일 게시물을 조회하는 기능 구현

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -13,13 +13,16 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
     @Published var selectedFrontImage: UIImage?
     @Published var selectedBackImage: UIImage?
     @Published var postsList: [PostData] = []
+    @Published var images: [PostData] = []
+    @Published var todayFrontImage: UIImage?
+    @Published var todayBackImage: UIImage?
     @Published var isLoading = false
     @Published var uploadStatus: String = ""
     
     private let photoSaveService = PhotoSaveService.shared
     
     init() {
-        loadRoomPosts()
+        loadTodayPosts()
     }
     
     func didCaptureImages(frontImage: UIImage, backImage: UIImage) {
@@ -30,7 +33,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
     
     func didUploadToRoomPosts(postData: PostData) {
         uploadStatus = "Room posts 업로드 완료: \(postData.uid)"
-        loadRoomPosts()
+        loadTodayPosts()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             self.uploadStatus = ""
@@ -56,6 +59,76 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
             case .failure(let error):
                 print("roomId 가져오기 실패: \(error.localizedDescription)")
             }
+        }
+    }
+
+    func loadTodayPosts() {
+        isLoading = true
+        photoSaveService.getCurrentUserRoomId { [weak self] result in
+            switch result {
+            case .success(let roomId):
+                self?.photoSaveService.fetchTodayRoomPosts(roomId: roomId) { result in
+                    DispatchQueue.main.async {
+                        self?.isLoading = false
+                        switch result {
+                        case .success(let todayPosts):
+                            self?.images = todayPosts
+                            print("📅 오늘 찍은 \(todayPosts.count)개 게시물 로드 완료")
+  
+                            if let firstPost = todayPosts.first {
+                                self?.downloadTodayImages(from: firstPost)
+                            } else {
+                                print("📭 오늘 찍은 게시물이 없습니다")
+                            }
+                        case .failure(let error):
+                            print("오늘 posts 로드 실패: \(error.localizedDescription)")
+                        }
+                    }
+                }
+            case .failure(let error):
+                print("roomId 가져오기 실패: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                }
+            }
+        }
+    }
+    
+    private func downloadTodayImages(from post: PostData) {
+        print("🖼️ 이미지 다운로드 시작")
+        
+        let group = DispatchGroup()
+
+        group.enter()
+        photoSaveService.downloadImage(from: post.frontImageURL) { [weak self] result in
+            switch result {
+            case .success(let image):
+                DispatchQueue.main.async {
+                    self?.todayFrontImage = image
+                    print("✅ 전면 이미지 다운로드 성공")
+                }
+            case .failure(let error):
+                print("❌ 전면 이미지 다운로드 실패: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        
+        group.enter()
+        photoSaveService.downloadImage(from: post.backImageURL) { [weak self] result in
+            switch result {
+            case .success(let image):
+                DispatchQueue.main.async {
+                    self?.todayBackImage = image
+                    print("✅ 후면 이미지 다운로드 성공")
+                }
+            case .failure(let error):
+                print("❌ 후면 이미지 다운로드 실패: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        
+        group.notify(queue: .main) {
+            print("🎉 오늘 이미지 다운로드 완료")
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -16,6 +16,7 @@ struct FeedView: View {
     @StateObject var viewModel: FeedViewModel
     
     @State var showCameraView: Bool = false
+    @State private var isRefreshing = false
     
     var body: some View {
         NavigationView {
@@ -23,17 +24,41 @@ struct FeedView: View {
                 ScrollView {
                     // 이미지 표시 영역
                     VStack {
-                        Text("Feed View")
+                        HStack {
+                            Text("Feed View")
+                            
+                            Spacer()
                         
-                        Button("로그아웃") {
-                            do {
-                                try Auth.auth().signOut()
-                            } catch {
-                                print("로그아웃 실패: \(error.localizedDescription)")
+                            Button(action: {
+                                print("🔄 수동 새로고침 시작")
+                                withAnimation(.linear(duration: 1).repeatCount(1, autoreverses: false)) {
+                                    isRefreshing = true
+                                }
+                                viewModel.loadTodayPosts()
+
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                    isRefreshing = false
+                                }
+                            }) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.title2)
+                                    .foregroundColor(.blue)
+                                    .rotationEffect(.degrees(isRefreshing ? 360 : 0))
+                            }
+                            .disabled(viewModel.isLoading)
+                            .padding(.trailing, 10)
+                            
+                            Button("로그아웃") {
+                                do {
+                                    try Auth.auth().signOut()
+                                } catch {
+                                    print("로그아웃 실패: \(error.localizedDescription)")
+                                }
                             }
                         }
-                        
-                        if let frontImage = viewModel.selectedFrontImage, let backImage = viewModel.selectedBackImage {
+                        .padding(.horizontal)
+ 
+                        if let frontImage = viewModel.todayFrontImage, let backImage = viewModel.todayBackImage {
                             ZStack{
                                 Image(uiImage: backImage)
                                     .resizable()
@@ -50,6 +75,21 @@ struct FeedView: View {
                                     .shadow(radius: 10)
                                     .padding()
                             }
+                        } else if viewModel.isLoading {
+                            RoundedRectangle(cornerRadius: 15)
+                                .fill(Color.gray.opacity(0.3))
+                                .frame(height: 300)
+                                .overlay(
+                                    VStack {
+                                        ProgressView()
+                                            .scaleEffect(1.5)
+                                        Text("로딩 중...")
+                                            .foregroundColor(.gray)
+                                            .font(.caption)
+                                            .padding(.top, 10)
+                                    }
+                                )
+                                .padding()
                         } else {
                             RoundedRectangle(cornerRadius: 15)
                                 .fill(Color.gray.opacity(0.3))
@@ -59,7 +99,11 @@ struct FeedView: View {
                                         Image(systemName: "camera")
                                             .font(.system(size: 50))
                                             .foregroundColor(.gray)
-                                        Text("커스텀 카메라로 사진을 촬영하세요")
+                                        Text("게시물을 올려주세요")
+                                            .foregroundColor(.gray)
+                                            .font(.headline)
+                                            .padding(.top, 10)
+                                        Text("오늘 찍은 사진이 없습니다")
                                             .foregroundColor(.gray)
                                             .font(.caption)
                                     }
@@ -84,25 +128,7 @@ struct FeedView: View {
                     }
                 }
                 
-                if viewModel.selectedFrontImage != nil || viewModel.selectedBackImage != nil {
-                    Button{
-                        viewModel.selectedFrontImage = nil
-                        viewModel.selectedBackImage = nil
-                    }label: {
-                        HStack {
-                            Image(systemName: "trash")
-                            Text("이미지 삭제")
-                        }
-                        .font(.headline)
-                        .foregroundColor(.white)
-                        .padding()
-                        .background{
-                            RoundedRectangle(cornerRadius: 20)
-                                .fill(Color.red)
-                        }
-                    }
-                    Spacer()
-                }
+                Spacer()
             }
             .navigationTitle("Boomoji")
         }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #32 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
기존
- FeedView에서 나타나는 이미지는 촬영 한 이미지를 로컬에서 보여줬음

변경
- roomId로 room의 posts를 조회
- posts에서 오늘 날짜로 필터링
- 필터링 된 post중 가장 최신 날짜의 사진을 다운로드 후 FeedView에 보이도록 함
- 촬영 후 뷰가 새로 그려지지 않아 새로고침 버튼으로 posts 재조회

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/a96f6313-eb63-4291-8cae-950978dd845c


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 앱 초기 진입시 posts 조회 -> 이미지 다운로드 -> FeedView 그리기 동작 테스트
- [x] 새로운 촬영시 FeedView 새로고침 테스트

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 현재 어색한 부분인 게시물 없음, 이미지 로딩 중, 게시물 있음 같은 분기 처리는 Lofi를 입히면서 해결해보겠습니다.
- 기능 구현만 봐주시면 감사하겠습니다.

---