### PR TITLE
fix: #41 앱 실행 이후 최초 업로드 후 재촬영시 CaptionView로 넘어가지 않는 버그 수정

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		8BA62EA42E9149A00054EB8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA62EA32E9149A00054EB8F /* AppDelegate.swift */; };
 		A1AEBED12E9110160006FBBA /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1AEBED02E9110120006FBBA /* CameraViewController.swift */; };
 		A1CBCA6B2E96439D000F01E2 /* PhotoSaveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CBCA6A2E96439D000F01E2 /* PhotoSaveService.swift */; };
+		A1F848EB2E98087E007F79BA /* CaptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F848EA2E98087E007F79BA /* CaptionView.swift */; };
+		A1F848ED2E980885007F79BA /* CaptionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F848EC2E980885007F79BA /* CaptionViewModel.swift */; };
+		A1F848F12E9808DA007F79BA /* CameraViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F848F02E9808DA007F79BA /* CameraViewContainer.swift */; };
 		CAA9AED62E8FC15C0047A89A /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9AEB92E8FC15C0047A89A /* AppCoordinator.swift */; };
 		CAA9AED72E8FC15C0047A89A /* AppRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9AEBA2E8FC15C0047A89A /* AppRoute.swift */; };
 		CAA9AED82E8FC15C0047A89A /* RootNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9AEBB2E8FC15C0047A89A /* RootNavigationView.swift */; };
@@ -53,6 +56,9 @@
 		8BA62EA32E9149A00054EB8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1AEBED02E9110120006FBBA /* CameraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewController.swift; sourceTree = "<group>"; };
 		A1CBCA6A2E96439D000F01E2 /* PhotoSaveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoSaveService.swift; sourceTree = "<group>"; };
+		A1F848EA2E98087E007F79BA /* CaptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionView.swift; sourceTree = "<group>"; };
+		A1F848EC2E980885007F79BA /* CaptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionViewModel.swift; sourceTree = "<group>"; };
+		A1F848F02E9808DA007F79BA /* CameraViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewContainer.swift; sourceTree = "<group>"; };
 		CA957C5C2E942B4200AEAB49 /* DonDog-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "DonDog-iOS.entitlements"; sourceTree = "<group>"; };
 		CAA9AE802E8FBE250047A89A /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAA9AEB92E8FC15C0047A89A /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -103,6 +109,31 @@
 				A1CBCA6A2E96439D000F01E2 /* PhotoSaveService.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		A1F848E72E9807B2007F79BA /* Caption */ = {
+			isa = PBXGroup;
+			children = (
+				A1F848E82E9807BB007F79BA /* Views */,
+				A1F848E92E9807C0007F79BA /* ViewModels */,
+			);
+			path = Caption;
+			sourceTree = "<group>";
+		};
+		A1F848E82E9807BB007F79BA /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A1F848EA2E98087E007F79BA /* CaptionView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		A1F848E92E9807C0007F79BA /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				A1F848EC2E980885007F79BA /* CaptionViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		CAA9AE772E8FBE250047A89A = {
@@ -173,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AECB2E8FC15C0047A89A /* CameraView.swift */,
+				A1F848F02E9808DA007F79BA /* CameraViewContainer.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -283,6 +315,7 @@
 				CAA9AEC72E8FC15C0047A89A /* Auth */,
 				CAA9AEE12E8FC17C0047A89A /* Invite */,
 				CAA9AECC2E8FC15C0047A89A /* Camera */,
+				A1F848E72E9807B2007F79BA /* Caption */,
 				CAA9AED12E8FC15C0047A89A /* Feed */,
 			);
 			path = Features;
@@ -386,13 +419,16 @@
 			files = (
 				CAA9AED62E8FC15C0047A89A /* AppCoordinator.swift in Sources */,
 				CAA9AED72E8FC15C0047A89A /* AppRoute.swift in Sources */,
+				A1F848ED2E980885007F79BA /* CaptionViewModel.swift in Sources */,
 				8B5F44562E90FA74003137F2 /* ProfileSetupView.swift in Sources */,
 				CAA9AED82E8FC15C0047A89A /* RootNavigationView.swift in Sources */,
 				CAA9AED92E8FC15C0047A89A /* DonDog_iOSApp.swift in Sources */,
+				A1F848EB2E98087E007F79BA /* CaptionView.swift in Sources */,
 				CAA9AEDA2E8FC15C0047A89A /* AuthViewModel.swift in Sources */,
 				A1CBCA6B2E96439D000F01E2 /* PhotoSaveService.swift in Sources */,
 				CAA9AEDB2E8FC15C0047A89A /* AuthView.swift in Sources */,
 				8B7377E02E9546030001EFCD /* AuthService.swift in Sources */,
+				A1F848F12E9808DA007F79BA /* CameraViewContainer.swift in Sources */,
 				CAA9AEDC2E8FC15C0047A89A /* CameraViewModel.swift in Sources */,
 				8BA62EA42E9149A00054EB8F /* AppDelegate.swift in Sources */,
 				CAA9AEE52E8FC1B40047A89A /* InviteView.swift in Sources */,

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CameraViewController.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CameraViewController.swift
@@ -217,7 +217,7 @@ class CustomCameraViewController: UIViewController {
             // 전면 → 후면으로 전환
             switchToBackCamera()
         } else {
-            // 후면 촬영 완료 → 메인 화면으로 돌아가기
+            // 후면 촬영 완료 → CaptionView로 이동
             delegate?.didCompleteBothPhotos()
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CameraViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CameraViewModel.swift
@@ -20,32 +20,5 @@ final class CameraViewModel: ObservableObject {
     var frontImage: UIImage?
     var backImage: UIImage?
     @Published var isUploading = false
-    
-    private let photoSaveService = PhotoSaveService.shared
-    
-    
-    func uploadImagesToRoomPosts() {
-        
-        guard let frontImage = frontImage, let backImage = backImage else {
-            print("❌ 전면 또는 후면 이미지가 없습니다")
-            return
-        }
-        
-        print("✅ 전면 이미지: \(frontImage.size), 후면 이미지: \(backImage.size)")
-        isUploading = true
-        
-        photoSaveService.uploadImagesToRoomPosts(frontImage: frontImage, backImage: backImage) { [weak self] result in
-            DispatchQueue.main.async {
-                self?.isUploading = false
-                
-                switch result {
-                case .success(let postData):
-                    print("🎉 Room posts 업로드 성공: \(postData.uid)")
-                    self?.delegate?.didUploadToRoomPosts(postData: postData)
-                case .failure(let error):
-                    print("💥 Room posts 업로드 실패: \(error.localizedDescription)")
-                }
-            }
-        }
-    }
+    @Published var showCaptionView = false
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CaptionViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CaptionViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  CaptionViewModel.swift
+//  DonDog-iOS
+//
+//  Created by 문창재 on 10/9/25.
+//
+
+import SwiftUI
+import Combine
+
+protocol CaptionViewModelDelegate: AnyObject {
+    func didUploadPost()
+}
+
+final class CaptionViewModel: ObservableObject {
+    @Published var caption: String = ""
+    @Published var isUploading: Bool = false
+    
+    weak var delegate: CaptionViewModelDelegate?
+    
+    var frontImage: UIImage?
+    var backImage: UIImage?
+    
+    private let photoSaveService = PhotoSaveService.shared
+    
+    init(frontImage: UIImage?, backImage: UIImage?) {
+        self.frontImage = frontImage
+        self.backImage = backImage
+    }
+    
+    func uploadPost() {
+        guard let frontImage = frontImage, let backImage = backImage else {
+            print("❌ 전면 또는 후면 이미지가 없습니다")
+            return
+        }
+        
+        print("📤 업로드 시작 - 캡션: \(caption)")
+        isUploading = true
+        
+        photoSaveService.uploadImagesToRoomPosts(
+            frontImage: frontImage,
+            backImage: backImage,
+            caption: caption
+        ) { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isUploading = false
+                
+                switch result {
+                case .success(let postData):
+                    print("✅ 업로드 성공: \(postData.uid)")
+                    print("📝 캡션: \(postData.caption)")
+                    self?.delegate?.didUploadPost()
+                case .failure(let error):
+                    print("❌ 업로드 실패: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraView.swift
@@ -43,18 +43,17 @@ struct CameraView: UIViewControllerRepresentable {
         }
         
         func didCompleteBothPhotos() {
-            print("📸 촬영 완료 - Firebase 업로드 시작")
-            
             if let frontImage = parent.viewModel.frontImage,
                let backImage = parent.viewModel.backImage {
                 parent.viewModel.delegate?.didCaptureImages(
                     frontImage: frontImage, 
                     backImage: backImage
                 )
-                
-                parent.viewModel.uploadImagesToRoomPosts()
+
+                DispatchQueue.main.async {
+                    self.parent.viewModel.showCaptionView = true
+                }
             }
-            parent.presentationMode.wrappedValue.dismiss()
         }
         
         func didCancel() {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraViewContainer.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraViewContainer.swift
@@ -1,0 +1,88 @@
+//
+//  CameraViewContainer.swift
+//  DonDog-iOS
+//
+//  Created by 문창재 on 10/9/25.
+//
+
+import SwiftUI
+
+struct CameraViewContainer: View {
+    @StateObject var cameraViewModel: CameraViewModel
+    @ObservedObject var feedViewModel: FeedViewModel
+    @Binding var isPresented: Bool
+    
+    @State private var captionViewModel: CaptionViewModel?
+    @State private var shouldDismiss = false
+    
+    init(cameraViewModel: CameraViewModel, feedViewModel: FeedViewModel, isPresented: Binding<Bool>) {
+        _cameraViewModel = StateObject(wrappedValue: cameraViewModel)
+        self.feedViewModel = feedViewModel
+        self._isPresented = isPresented
+    }
+    
+    var body: some View {
+        ZStack {
+            CameraView(viewModel: cameraViewModel)
+                .ignoresSafeArea()
+            
+            if cameraViewModel.showCaptionView {
+                if let captionVM = captionViewModel {
+                    CaptionView(viewModel: captionVM) {
+                        withAnimation {
+                            cameraViewModel.showCaptionView = false
+                        }
+                    }
+                    .transition(.move(edge: .bottom))
+                }
+            }
+        }
+        .onChange(of: cameraViewModel.showCaptionView) { newValue in
+            if newValue {
+                let newCaptionVM = CaptionViewModel(
+                    frontImage: cameraViewModel.frontImage,
+                    backImage: cameraViewModel.backImage
+                )
+                
+                newCaptionVM.delegate = ContainerDelegate(
+                    onUploadComplete: { [self] in
+                        handleUploadComplete()
+                    }
+                )
+                
+                captionViewModel = newCaptionVM
+            }
+        }
+        .onChange(of: shouldDismiss) { newValue in
+            if newValue {
+                isPresented = false
+            }
+        }
+    }
+    
+    private func handleUploadComplete() {
+        
+        feedViewModel.didUploadPost()
+        
+        cameraViewModel.frontImage = nil
+        cameraViewModel.backImage = nil
+        cameraViewModel.showCaptionView = false
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.shouldDismiss = true
+        }
+    }
+    
+    class ContainerDelegate: CaptionViewModelDelegate {
+        let onUploadComplete: () -> Void
+        
+        init(onUploadComplete: @escaping () -> Void) {
+            self.onUploadComplete = onUploadComplete
+        }
+        
+        func didUploadPost() {
+            onUploadComplete()
+        }
+    }
+}
+

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraViewContainer.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraViewContainer.swift
@@ -30,7 +30,7 @@ struct CameraViewContainer: View {
                 if let captionVM = captionViewModel {
                     CaptionView(viewModel: captionVM) {
                         withAnimation {
-                            cameraViewModel.showCaptionView = false
+                            shouldDismiss = true
                         }
                     }
                     .transition(.move(edge: .bottom))

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraViewContainer.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CameraViewContainer.swift
@@ -31,6 +31,7 @@ struct CameraViewContainer: View {
                     CaptionView(viewModel: captionVM) {
                         withAnimation {
                             shouldDismiss = true
+                            cameraViewModel.showCaptionView = false
                         }
                     }
                     .transition(.move(edge: .bottom))

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Views/CaptionView.swift
@@ -1,0 +1,126 @@
+//
+//  CaptionView.swift
+//  DonDog-iOS
+//
+//  Created by 문창재 on 10/9/25.
+//
+
+import SwiftUI
+
+struct CaptionView: View {
+    @ObservedObject var viewModel: CaptionViewModel
+    var onCancel: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // 상단 타이틀
+            HStack {
+                Button(action: {
+                    onCancel()
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.title2)
+                        .foregroundColor(.black)
+                }
+                
+                Spacer()
+                
+                Text("캡션 작성")
+                    .font(.headline)
+                
+                Spacer()
+                
+                // 빈 공간 (대칭을 위해)
+                Image(systemName: "xmark")
+                    .font(.title2)
+                    .opacity(0)
+            }
+            .padding()
+            
+            // 전면/후면 사진 미리보기
+            HStack(spacing: 10) {
+                if let frontImage = viewModel.frontImage {
+                    VStack {
+                        Text("전면")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        Image(uiImage: frontImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 200)
+                            .cornerRadius(10)
+                            .shadow(radius: 5)
+                    }
+                }
+                
+                if let backImage = viewModel.backImage {
+                    VStack {
+                        Text("후면")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        Image(uiImage: backImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 200)
+                            .cornerRadius(10)
+                            .shadow(radius: 5)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            
+            // 캡션 입력 필드
+            VStack(alignment: .leading, spacing: 5) {
+                Text("캡션 (최대 8자)")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                
+                TextField("오늘의 한마디를 입력하세요", text: $viewModel.caption)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(10)
+                    .onChange(of: viewModel.caption) { newValue in
+                        // 8자 제한
+                        if newValue.count > 8 {
+                            viewModel.caption = String(newValue.prefix(8))
+                        }
+                    }
+                
+                Text("\(viewModel.caption.count)/8")
+                    .font(.caption)
+                    .foregroundColor(viewModel.caption.count >= 8 ? .red : .gray)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .padding(.horizontal)
+            
+            Spacer()
+            
+            // 업로드 버튼
+            Button(action: {
+                print("📤 업로드 버튼 클릭")
+                viewModel.uploadPost()
+            }) {
+                if viewModel.isUploading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                } else {
+                    Text("업로드하기")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                }
+            }
+            .background(viewModel.isUploading ? Color.gray : Color.blue)
+            .cornerRadius(10)
+            .disabled(viewModel.isUploading)
+            .padding(.horizontal)
+            .padding(.bottom, 30)
+        }
+        .background(Color.white)
+    }
+}
+

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/ViewModels/CaptionViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/ViewModels/CaptionViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  CaptionViewModel.swift
+//  DonDog-iOS
+//
+//  Created by 문창재 on 10/9/25.
+//
+
+import SwiftUI
+import Combine
+
+protocol CaptionViewModelDelegate: AnyObject {
+    func didUploadPost()
+}
+
+final class CaptionViewModel: ObservableObject {
+    @Published var caption: String = ""
+    @Published var isUploading: Bool = false
+    
+    weak var delegate: CaptionViewModelDelegate?
+    
+    var frontImage: UIImage?
+    var backImage: UIImage?
+    
+    private let photoSaveService = PhotoSaveService.shared
+    
+    init(frontImage: UIImage?, backImage: UIImage?) {
+        self.frontImage = frontImage
+        self.backImage = backImage
+    }
+    
+    func uploadPost() {
+        guard let frontImage = frontImage, let backImage = backImage else {
+            print("❌ 전면 또는 후면 이미지가 없습니다")
+            return
+        }
+        
+        print("📤 업로드 시작 - 캡션: \(caption)")
+        isUploading = true
+        
+        photoSaveService.uploadImagesToRoomPosts(
+            frontImage: frontImage,
+            backImage: backImage,
+            caption: caption
+        ) { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isUploading = false
+                
+                switch result {
+                case .success(let postData):
+                    print("✅ 업로드 성공: \(postData.uid)")
+                    print("📝 캡션: \(postData.caption)")
+                    self?.delegate?.didUploadPost()
+                case .failure(let error):
+                    print("❌ 업로드 실패: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/ViewModels/CaptionViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/ViewModels/CaptionViewModel.swift
@@ -53,6 +53,8 @@ final class CaptionViewModel: ObservableObject {
                 case .failure(let error):
                     print("❌ 업로드 실패: \(error.localizedDescription)")
                 }
+                
+                
             }
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -37,7 +37,6 @@ struct CaptionView: View {
             }
             .padding()
             
-            // 전면/후면 사진 미리보기
             HStack(spacing: 10) {
                 if let frontImage = viewModel.frontImage {
                     VStack {
@@ -47,6 +46,7 @@ struct CaptionView: View {
                         Image(uiImage: frontImage)
                             .resizable()
                             .scaledToFit()
+                            .scaleEffect(x: -1, y:1)
                             .frame(height: 200)
                             .cornerRadius(10)
                             .shadow(radius: 5)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -116,6 +116,11 @@ struct CaptionView: View {
             .disabled(viewModel.isUploading)
             .padding(.horizontal)
             .padding(.bottom, 30)
+            .onChange(of: viewModel.isUploading) { newValue in
+                if newValue == false{
+                    onCancel()
+                }
+            }
         }
         .background(Color.white)
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -1,0 +1,123 @@
+//
+//  CaptionView.swift
+//  DonDog-iOS
+//
+//  Created by 문창재 on 10/9/25.
+//
+
+import SwiftUI
+
+struct CaptionView: View {
+    @ObservedObject var viewModel: CaptionViewModel
+    var onCancel: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // 상단 타이틀
+            HStack {
+                Button(action: {
+                    onCancel()
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.title2)
+                        .foregroundColor(.black)
+                }
+                
+                Spacer()
+                
+                Text("캡션 작성")
+                    .font(.headline)
+                
+                Spacer()
+                
+                // 빈 공간 (대칭을 위해)
+                Image(systemName: "xmark")
+                    .font(.title2)
+                    .opacity(0)
+            }
+            .padding()
+            
+            // 전면/후면 사진 미리보기
+            HStack(spacing: 10) {
+                if let frontImage = viewModel.frontImage {
+                    VStack {
+                        Text("전면")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        Image(uiImage: frontImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 200)
+                            .cornerRadius(10)
+                            .shadow(radius: 5)
+                    }
+                }
+                
+                if let backImage = viewModel.backImage {
+                    VStack {
+                        Text("후면")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        Image(uiImage: backImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 200)
+                            .cornerRadius(10)
+                            .shadow(radius: 5)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            
+            VStack(alignment: .leading, spacing: 5) {
+                Text("캡션 (최대 8자)")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                
+                TextField("오늘의 한마디를 입력하세요", text: $viewModel.caption)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(10)
+                    .onChange(of: viewModel.caption) { newValue in
+                        if newValue.count > 8 {
+                            viewModel.caption = String(newValue.prefix(8))
+                        }
+                    }
+                
+                Text("\(viewModel.caption.count)/8")
+                    .font(.caption)
+                    .foregroundColor(viewModel.caption.count >= 8 ? .red : .gray)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .padding(.horizontal)
+            
+            Spacer()
+
+            Button(action: {
+                print("📤 업로드 버튼 클릭")
+                viewModel.uploadPost()
+            }) {
+                if viewModel.isUploading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                } else {
+                    Text("업로드하기")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                }
+            }
+            .background(viewModel.isUploading ? Color.gray : Color.blue)
+            .cornerRadius(10)
+            .disabled(viewModel.isUploading)
+            .padding(.horizontal)
+            .padding(.bottom, 30)
+        }
+        .background(Color.white)
+    }
+}
+

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -13,13 +13,16 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
     @Published var selectedFrontImage: UIImage?
     @Published var selectedBackImage: UIImage?
     @Published var postsList: [PostData] = []
+    @Published var images: [PostData] = []
+    @Published var todayFrontImage: UIImage?
+    @Published var todayBackImage: UIImage?
     @Published var isLoading = false
     @Published var uploadStatus: String = ""
     
     private let photoSaveService = PhotoSaveService.shared
     
     init() {
-        loadRoomPosts()
+        loadTodayPosts()
     }
     
     func didCaptureImages(frontImage: UIImage, backImage: UIImage) {
@@ -30,7 +33,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
     
     func didUploadToRoomPosts(postData: PostData) {
         uploadStatus = "Room posts 업로드 완료: \(postData.uid)"
-        loadRoomPosts()
+        loadTodayPosts()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             self.uploadStatus = ""
@@ -56,6 +59,76 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
             case .failure(let error):
                 print("roomId 가져오기 실패: \(error.localizedDescription)")
             }
+        }
+    }
+
+    func loadTodayPosts() {
+        isLoading = true
+        photoSaveService.getCurrentUserRoomId { [weak self] result in
+            switch result {
+            case .success(let roomId):
+                self?.photoSaveService.fetchTodayRoomPosts(roomId: roomId) { result in
+                    DispatchQueue.main.async {
+                        self?.isLoading = false
+                        switch result {
+                        case .success(let todayPosts):
+                            self?.images = todayPosts
+                            print("📅 오늘 찍은 \(todayPosts.count)개 게시물 로드 완료")
+  
+                            if let firstPost = todayPosts.first {
+                                self?.downloadTodayImages(from: firstPost)
+                            } else {
+                                print("📭 오늘 찍은 게시물이 없습니다")
+                            }
+                        case .failure(let error):
+                            print("오늘 posts 로드 실패: \(error.localizedDescription)")
+                        }
+                    }
+                }
+            case .failure(let error):
+                print("roomId 가져오기 실패: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                }
+            }
+        }
+    }
+    
+    private func downloadTodayImages(from post: PostData) {
+        print("🖼️ 이미지 다운로드 시작")
+        
+        let group = DispatchGroup()
+
+        group.enter()
+        photoSaveService.downloadImage(from: post.frontImageURL) { [weak self] result in
+            switch result {
+            case .success(let image):
+                DispatchQueue.main.async {
+                    self?.todayFrontImage = image
+                    print("✅ 전면 이미지 다운로드 성공")
+                }
+            case .failure(let error):
+                print("❌ 전면 이미지 다운로드 실패: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        
+        group.enter()
+        photoSaveService.downloadImage(from: post.backImageURL) { [weak self] result in
+            switch result {
+            case .success(let image):
+                DispatchQueue.main.async {
+                    self?.todayBackImage = image
+                    print("✅ 후면 이미지 다운로드 성공")
+                }
+            case .failure(let error):
+                print("❌ 후면 이미지 다운로드 실패: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        
+        group.notify(queue: .main) {
+            print("🎉 오늘 이미지 다운로드 완료")
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -9,7 +9,7 @@ import Combine
 import UIKit
 
 
-final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
+final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionViewModelDelegate {
     @Published var selectedFrontImage: UIImage?
     @Published var selectedBackImage: UIImage?
     @Published var postsList: [PostData] = []
@@ -38,6 +38,12 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             self.uploadStatus = ""
         }
+    }
+    
+    // MARK: - CaptionViewModelDelegate
+    func didUploadPost() {
+        print("✅ 게시물 업로드 완료 - FeedView 새로고침")
+        loadTodayPosts()
     }
     
     

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -16,6 +16,7 @@ struct FeedView: View {
     @StateObject var viewModel: FeedViewModel
     
     @State var showCameraView: Bool = false
+    @State private var isRefreshing = false
     
     var body: some View {
         NavigationView {
@@ -23,17 +24,41 @@ struct FeedView: View {
                 ScrollView {
                     // 이미지 표시 영역
                     VStack {
-                        Text("Feed View")
+                        HStack {
+                            Text("Feed View")
+                            
+                            Spacer()
                         
-                        Button("로그아웃") {
-                            do {
-                                try Auth.auth().signOut()
-                            } catch {
-                                print("로그아웃 실패: \(error.localizedDescription)")
+                            Button(action: {
+                                print("🔄 수동 새로고침 시작")
+                                withAnimation(.linear(duration: 1).repeatCount(1, autoreverses: false)) {
+                                    isRefreshing = true
+                                }
+                                viewModel.loadTodayPosts()
+
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                    isRefreshing = false
+                                }
+                            }) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.title2)
+                                    .foregroundColor(.blue)
+                                    .rotationEffect(.degrees(isRefreshing ? 360 : 0))
+                            }
+                            .disabled(viewModel.isLoading)
+                            .padding(.trailing, 10)
+                            
+                            Button("로그아웃") {
+                                do {
+                                    try Auth.auth().signOut()
+                                } catch {
+                                    print("로그아웃 실패: \(error.localizedDescription)")
+                                }
                             }
                         }
-                        
-                        if let frontImage = viewModel.selectedFrontImage, let backImage = viewModel.selectedBackImage {
+                        .padding(.horizontal)
+ 
+                        if let frontImage = viewModel.todayFrontImage, let backImage = viewModel.todayBackImage {
                             ZStack{
                                 Image(uiImage: backImage)
                                     .resizable()
@@ -50,6 +75,21 @@ struct FeedView: View {
                                     .shadow(radius: 10)
                                     .padding()
                             }
+                        } else if viewModel.isLoading {
+                            RoundedRectangle(cornerRadius: 15)
+                                .fill(Color.gray.opacity(0.3))
+                                .frame(height: 300)
+                                .overlay(
+                                    VStack {
+                                        ProgressView()
+                                            .scaleEffect(1.5)
+                                        Text("로딩 중...")
+                                            .foregroundColor(.gray)
+                                            .font(.caption)
+                                            .padding(.top, 10)
+                                    }
+                                )
+                                .padding()
                         } else {
                             RoundedRectangle(cornerRadius: 15)
                                 .fill(Color.gray.opacity(0.3))
@@ -59,7 +99,11 @@ struct FeedView: View {
                                         Image(systemName: "camera")
                                             .font(.system(size: 50))
                                             .foregroundColor(.gray)
-                                        Text("커스텀 카메라로 사진을 촬영하세요")
+                                        Text("게시물을 올려주세요")
+                                            .foregroundColor(.gray)
+                                            .font(.headline)
+                                            .padding(.top, 10)
+                                        Text("오늘 찍은 사진이 없습니다")
                                             .foregroundColor(.gray)
                                             .font(.caption)
                                     }
@@ -84,25 +128,7 @@ struct FeedView: View {
                     }
                 }
                 
-                if viewModel.selectedFrontImage != nil || viewModel.selectedBackImage != nil {
-                    Button{
-                        viewModel.selectedFrontImage = nil
-                        viewModel.selectedBackImage = nil
-                    }label: {
-                        HStack {
-                            Image(systemName: "trash")
-                            Text("이미지 삭제")
-                        }
-                        .font(.headline)
-                        .foregroundColor(.white)
-                        .padding()
-                        .background{
-                            RoundedRectangle(cornerRadius: 20)
-                                .fill(Color.red)
-                        }
-                    }
-                    Spacer()
-                }
+                Spacer()
             }
             .navigationTitle("Boomoji")
         }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -17,6 +17,7 @@ struct FeedView: View {
     
     @State var showCameraView: Bool = false
     @State private var isRefreshing = false
+    @StateObject private var cameraViewModel = CameraViewModel()
     
     var body: some View {
         NavigationView {
@@ -59,21 +60,34 @@ struct FeedView: View {
                         .padding(.horizontal)
  
                         if let frontImage = viewModel.todayFrontImage, let backImage = viewModel.todayBackImage {
-                            ZStack{
-                                Image(uiImage: backImage)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(maxHeight: 400)
-                                    .cornerRadius(15)
-                                    .shadow(radius: 10)
-                                Image(uiImage: frontImage)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .scaleEffect(x: -1, y:1)
-                                    .frame(maxHeight: 100)
-                                    .cornerRadius(15)
-                                    .shadow(radius: 10)
-                                    .padding()
+                            VStack(spacing: 10) {
+                                ZStack{
+                                    Image(uiImage: backImage)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 400)
+                                        .cornerRadius(15)
+                                        .shadow(radius: 10)
+                                    Image(uiImage: frontImage)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .scaleEffect(x: -1, y:1)
+                                        .frame(maxHeight: 100)
+                                        .cornerRadius(15)
+                                        .shadow(radius: 10)
+                                        .padding()
+                                }
+                                
+                                // 캡션 표시
+                                if let firstPost = viewModel.images.first, !firstPost.caption.isEmpty {
+                                    Text(firstPost.caption)
+                                        .font(.body)
+                                        .foregroundColor(.black)
+                                        .padding(.horizontal)
+                                        .padding(.vertical, 8)
+                                        .background(Color.gray.opacity(0.1))
+                                        .cornerRadius(8)
+                                }
                             }
                         } else if viewModel.isLoading {
                             RoundedRectangle(cornerRadius: 15)
@@ -133,8 +147,11 @@ struct FeedView: View {
             .navigationTitle("Boomoji")
         }
         .fullScreenCover(isPresented: $showCameraView) {
-            ModuleFactory.shared.makeCameraView(with: viewModel)
-                .ignoresSafeArea()
+            CameraViewContainer(
+                cameraViewModel: cameraViewModel,
+                feedViewModel: viewModel,
+                isPresented: $showCameraView
+            )
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Services/PhotoSaveService.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Services/PhotoSaveService.swift
@@ -15,12 +15,14 @@ struct PostData: Codable {
     let uid: String
     let frontImageURL: String
     let backImageURL: String
+    let caption: String
     let createdAt: Timestamp
     
-    init(uid: String, frontImageURL: String, backImageURL: String) {
+    init(uid: String, frontImageURL: String, backImageURL: String, caption: String = "") {
         self.uid = uid
         self.frontImageURL = frontImageURL
         self.backImageURL = backImageURL
+        self.caption = caption
         self.createdAt = Timestamp()
     }
 }
@@ -36,7 +38,7 @@ final class PhotoSaveService: ObservableObject {
     private init() {}
     
     // MARK: - : Room의 posts에 저장
-    func uploadImagesToRoomPosts(frontImage: UIImage, backImage: UIImage, completion: @escaping (Result<PostData, Error>) -> Void) {
+    func uploadImagesToRoomPosts(frontImage: UIImage, backImage: UIImage, caption: String, completion: @escaping (Result<PostData, Error>) -> Void) {
         print("🏠 Room의 posts에 전면/후면 이미지 업로드 시작")
         
         getCurrentUserRoomId { [weak self] result in
@@ -44,7 +46,7 @@ final class PhotoSaveService: ObservableObject {
             case .success(let roomId):
                 print("✅ 사용자 roomId: \(roomId)")
                 
-                self?.uploadImagesAndSaveToRoom(frontImage: frontImage, backImage: backImage, roomId: roomId, completion: completion)
+                self?.uploadImagesAndSaveToRoom(frontImage: frontImage, backImage: backImage, caption: caption, roomId: roomId, completion: completion)
             case .failure(let error):
                 print("❌ roomId 가져오기 실패: \(error.localizedDescription)")
                 completion(.failure(error))
@@ -86,7 +88,7 @@ final class PhotoSaveService: ObservableObject {
     }
     
     
-    private func uploadImagesAndSaveToRoom(frontImage: UIImage, backImage: UIImage, roomId: String, completion: @escaping (Result<PostData, Error>) -> Void) {
+    private func uploadImagesAndSaveToRoom(frontImage: UIImage, backImage: UIImage, caption: String, roomId: String, completion: @escaping (Result<PostData, Error>) -> Void) {
         guard let currentUser = Auth.auth().currentUser else {
             completion(.failure(FirebaseError.userNotAuthenticated))
             return
@@ -143,7 +145,7 @@ final class PhotoSaveService: ObservableObject {
             
             print("✅ 전면/후면 이미지 업로드 모두 완료")
             
-            let postData = PostData(uid: uid, frontImageURL: frontURL, backImageURL: backURL)
+            let postData = PostData(uid: uid, frontImageURL: frontURL, backImageURL: backURL, caption: caption)
             self.savePostToRoom(roomId: roomId, postId: postId, postData: postData, completion: completion)
         }
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #41 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 앱 실행 이후 최초 업로드 후 재촬영시 CaptionView로 넘어가지 않는 버그 수정
- 게시물 업로드 완료 후 CaptionView의 presentation State 관리

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/253bb9b6-5c9c-4c76-b3f0-566f1da1c12e


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 재촬영시 CpationView로 넘어가는 것 확인

---
