### PR TITLE
feat: #56 설정뷰 중 프로필 수정 뷰

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/ProfileSetupView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/ProfileSetupView.swift
@@ -15,6 +15,19 @@ struct ProfileSetupView: View {
         VStack(spacing: 24) {
             Text("Profile Setup View")
                 .font(.title)
+            
+            HStack(spacing: 24) {
+                ForEach(ProfileSetupViewModel.Role.allCases, id: \.self) { role in
+                    RoleCircleOption(
+                        title: role.displayName,
+                        isSelected: viewModel.selectedRole == role
+                    ) {
+                        viewModel.selectedRole = role
+                    }
+                    .accessibilityLabel(Text(role.displayName))
+                    .accessibilityAddTraits(viewModel.selectedRole == role ? .isSelected : [])
+                }
+            }
 
             VStack(alignment: .leading, spacing: 12) {
                 Text("이름/닉네임")
@@ -27,17 +40,6 @@ struct ProfileSetupView: View {
                         RoundedRectangle(cornerRadius: 8)
                             .stroke(Color.gray.opacity(0.3))
                     )
-            }
-
-            VStack(alignment: .leading, spacing: 12) {
-                Text("역할 (role)")
-                    .font(.headline)
-                Picker("역할", selection: $viewModel.selectedRole) {
-                    ForEach(ProfileSetupViewModel.Role.allCases, id: \.self) { role in
-                        Text(role.displayName).tag(role)
-                    }
-                }
-                .pickerStyle(.segmented)
             }
 
             if let error = viewModel.errorMessage {
@@ -69,5 +71,4 @@ struct ProfileSetupView: View {
         }
     }
 }
-
 

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -24,6 +24,7 @@ struct FeedView: View {
             ScrollView {
                 // 이미지 표시 영역
                 VStack {
+                    Button("연결뷰로 이동") { coordinator.push(.invite) }
                     Button("설정뷰로 이동") { coordinator.push(.setting) }
                     
                     HStack {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/Views/EditProfileView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/Views/EditProfileView.swift
@@ -12,7 +12,87 @@ struct EditProfileView: View {
     @StateObject var viewModel: EditProfileViewModel
     
     var body: some View {
-        Text("Profile Edit View")
+        VStack(spacing: 24) {
+            Text("프로필 수정")
+                .font(.title)
+            
+            // 역할
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 24) {
+                    ForEach(ProfileSetupViewModel.Role.allCases, id: \.self) { role in
+                        RoleCircleOption(
+                            title: role.displayName,
+                            isSelected: viewModel.selectedRole == role
+                        ) {
+                            viewModel.selectedRole = role
+                            viewModel.checkIfModified()
+                        }
+                        .accessibilityLabel(Text(role.displayName))
+                        .accessibilityAddTraits(viewModel.selectedRole == role ? .isSelected : [])
+                    }
+                }
+            }
+            
+            // 닉네임
+            VStack(alignment: .leading, spacing: 12) {
+                Text("이름/닉네임")
+                    .font(.headline)
+                TextField("이름/닉네임을 입력하세요", text: $viewModel.name)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.3))
+                    )
+                    .onChange(of: viewModel.name) {
+                        viewModel.checkIfModified()
+                    }
+            }
+            
+            // 에러 메시지
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.footnote)
+            }
+            
+            // 저장 버튼
+            Button(action: {
+                viewModel.saveChanges()
+            }) {
+                Text("저장 (Save)")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!viewModel.isValid || !viewModel.didChangeFromInitial)
+        }
+        .padding(20)
+        .onAppear {
+            viewModel.fetchCurrentProfile()
+        }
+        .onChange(of: viewModel.saveCompleted) { _, newValue in
+            if newValue {
+                coordinator.pop()
+            }
+        }
+    }
+}
+
+struct RoleCircleOption: View {
+    let title: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .strokeBorder(isSelected ? Color.black : Color.gray.opacity(0.35), lineWidth: isSelected ? 4 : 2)
+                    .frame(width: 80, height: 80)
+
+                Text(title)
+            }
+            .contentShape(Circle())
+            .onTapGesture { onTap() }
+        }
     }
 }
 

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViweModels/EditProfileViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViweModels/EditProfileViewModel.swift
@@ -5,9 +5,102 @@
 //  Created by 이주현 on 10/11/25.
 //
 
+import Foundation
 import Combine
-import SwiftUI
+import FirebaseAuth
+import FirebaseFirestore
 
 final class EditProfileViewModel: ObservableObject {
-    
+    typealias Role = ProfileSetupViewModel.Role
+    @Published var name: String = ""
+    @Published var selectedRole: Role = .parent
+
+    @Published var errorMessage: String?
+    @Published var saveCompleted: Bool = false    // 저장 완료 플래그
+    @Published private(set) var didChangeFromInitial: Bool = false
+
+    private let db = Firestore.firestore()
+    private var initialName: String = ""
+    private var initialRole: Role = .parent
+
+    // 유효성 검사: 공백/개행 제거 후 비어있지 않아야 함
+    var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Public APIs
+    func fetchCurrentProfile() {
+        errorMessage = nil
+
+        guard let uid = Auth.auth().currentUser?.uid else {
+            self.errorMessage = "로그인 상태가 아닙니다. 다시 로그인해 주세요."
+            return
+        }
+
+        let docRef = db.collection("Users").document(uid)
+        docRef.getDocument { [weak self] snap, err in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                if let err = err {
+                    self.errorMessage = "프로필 정보를 불러오지 못했습니다. (\(err.localizedDescription))"
+                    return
+                }
+                guard let data = snap?.data(), let snap = snap, snap.exists else {
+                    self.errorMessage = "프로필 정보가 없습니다. 먼저 프로필을 생성해 주세요."
+                    return
+                }
+
+                let loadedName = (data["name"] as? String) ?? ""
+                let loadedRoleRaw = (data["role"] as? String) ?? "parent"
+                let loadedRole = Role(rawValue: loadedRoleRaw) ?? .parent
+
+                self.name = loadedName
+                self.selectedRole = loadedRole
+
+                self.initialName = loadedName
+                self.initialRole = loadedRole
+                self.checkIfModified()
+            }
+        }
+    }
+
+    func saveChanges() {
+        errorMessage = nil
+
+        guard isValid else {
+            errorMessage = "닉네임을 입력해 주세요."
+            return
+        }
+        guard let uid = Auth.auth().currentUser?.uid else {
+            errorMessage = "로그인 상태가 아닙니다. 다시 로그인해 주세요."
+            return
+        }
+
+        let userDoc = db.collection("Users").document(uid)
+        userDoc.setData([
+            "name": name,
+            "role": selectedRole.rawForDB,
+            "updatedAt": FieldValue.serverTimestamp()
+        ], merge: true) { [weak self] err in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                if let err = err {
+                    self.errorMessage = "저장에 실패했습니다. 잠시 후 다시 시도해 주세요. (\(err.localizedDescription))"
+                    return
+                }
+
+                self.initialName = self.name
+                self.initialRole = self.selectedRole
+                self.checkIfModified()
+
+                self.saveCompleted = true
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    func checkIfModified() {
+        didChangeFromInitial = (name != initialName) || (selectedRole != initialRole)
+    }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Services/AuthService.swift
@@ -75,17 +75,6 @@ final class AuthService {
                 if userDoc.metadata.hasPendingWrites {
                     return
                 }
-                
-                if userDoc.exists {
-                    let roomId = (userDoc.get("roomId") as? String) ?? ""
-                    if roomId.isEmpty {
-                        replaceRootinAuthService(.invite, coordinator: coordinator)
-                    } else {
-                        replaceRootinAuthService(.feed, coordinator: coordinator)
-                    }
-                } else {
-                    replaceRootinAuthService(.profileSetup, coordinator: coordinator)
-                }
             }
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Services/AuthService.swift
@@ -72,6 +72,11 @@ final class AuthService {
                     return
                 }
                 
+                if userDoc == nil || userDoc.exists == false {
+                    replaceRootinAuthService(.profileSetup, coordinator: coordinator)
+                    return
+                }
+                
                 if userDoc.metadata.hasPendingWrites {
                     return
                 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #56 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 설정뷰 중 프로필 수정하는 뷰 생성
- 역할 선택 UI RoleCircleOption 컴포넌트로 분리, 동일한 ui 프로필 첫 세팅뷰에서도 적용 -> 추후 `Components/` 디렉토리 생성 시 `RoleCircleOption` 파일로 이동 예정 (코드 프리징 기간에 진행)
- 라우팅 로직 수정
  - 기존에는 `Users/{uid}` 문서에 `roomId`가 없을 경우 무조건 연결(Invite) 뷰로 이동하도록 되어 있었음. 하지만 피그마 설계상 피드뷰로 이동하는게 기본 값이라, 해당 조건 제거. 
  - 이로 인해 연결 뷰로 진입할 방법이 사라져 임시로 FeedView에 디버깅 코드 추가함 (테스트용)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/0404fbd3-29e6-4b81-8869-8c27bdb36851


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 서버 실시간 반영 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- ProfileSetupView와 EditProfileView 코드 구조가 유사해서 두 뷰를 통합할 수 있을 것 같음. 코드 프리징 기간에 리팩토링 시도하겠음

