### PR TITLE
feat: #65 게시물 및 댓글 삭제 권한 설정

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		D24402B02E992E7200D837C8 /* DataUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24402AE2E992E7200D837C8 /* DataUtils.swift */; };
 		D2A7F38A2E9A28B8005F5AF8 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A7F3892E9A28B7005F5AF8 /* Comment.swift */; };
 		D2A7F38C2E9BA88F005F5AF8 /* StickerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A7F38B2E9BA88A005F5AF8 /* StickerUtils.swift */; };
+		D2A7F3932E9CEC9A005F5AF8 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D2A7F3922E9CEC9A005F5AF8 /* GoogleService-Info.plist */; };
 		D2D16C002E9153B7008FB3E2 /* PostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D16BFF2E9153B2008FB3E2 /* PostViewModel.swift */; };
 		D2D16C022E9153BE008FB3E2 /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D16C012E9153BC008FB3E2 /* PostView.swift */; };
 /* End PBXBuildFile section */
@@ -101,6 +102,7 @@
 		D24402AE2E992E7200D837C8 /* DataUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUtils.swift; sourceTree = "<group>"; };
 		D2A7F3892E9A28B7005F5AF8 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		D2A7F38B2E9BA88A005F5AF8 /* StickerUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerUtils.swift; sourceTree = "<group>"; };
+		D2A7F3922E9CEC9A005F5AF8 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D2D16BFF2E9153B2008FB3E2 /* PostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewModel.swift; sourceTree = "<group>"; };
 		D2D16C012E9153BC008FB3E2 /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -329,6 +331,7 @@
 			children = (
 				CA957C5C2E942B4200AEAB49 /* DonDog-iOS.entitlements */,
 				8B5F44592E90FF95003137F2 /* Info.plist */,
+				D2A7F3922E9CEC9A005F5AF8 /* GoogleService-Info.plist */,
 				CAA9AEBE2E8FC15C0047A89A /* App */,
 				CA957CEB2E98FC3D00AEAB49 /* Core */,
 				CAA9AED22E8FC15C0047A89A /* Presentation */,
@@ -506,6 +509,7 @@
 				CA957D012E98FCD700AEAB49 /* Pretendard-Regular.otf in Resources */,
 				CAA9AEE02E8FC15C0047A89A /* Assets.xcassets in Resources */,
 				CA957D072E99017400AEAB49 /* Colors.xcassets in Resources */,
+				D2A7F3932E9CEC9A005F5AF8 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -684,7 +688,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DonDog-iOS/DonDog-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8FKM9FB4PH;
+				DEVELOPMENT_TEAM = A65CGWHSL8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DonDog-iOS/Info.plist";
@@ -720,7 +724,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DonDog-iOS/DonDog-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8FKM9FB4PH;
+				DEVELOPMENT_TEAM = A65CGWHSL8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DonDog-iOS/Info.plist";

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/PostContentView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/PostContentView.swift
@@ -45,7 +45,7 @@ struct PostContentView: View {
             }
             
             List {
-                ForEach(viewModel.comments) { comment in
+                ForEach(viewModel.comments.filter { $0.uid == viewModel.currentUser }) { comment in
                     VStack(alignment: .leading, spacing: 7) {
                         HStack(spacing: 20) {
                             Text(comment.author)
@@ -64,9 +64,27 @@ struct PostContentView: View {
                 }
                 .onDelete { indexSet in
                     for index in indexSet {
-                        let comment = viewModel.comments[index]
+                        let comment = viewModel.comments.filter { $0.uid == viewModel.currentUser }[index]
                         viewModel.deleteComment(of: comment)
                     }
+                }
+                
+                ForEach(viewModel.comments.filter { $0.uid != viewModel.currentUser }) { comment in
+                    VStack(alignment: .leading, spacing: 7) {
+                        HStack(spacing: 20) {
+                            Text(comment.author)
+                                .font(.system(size: 18))
+                                .foregroundStyle(.gray)
+                            Text(DataUtils.formatDate(comment.timestamp, format: "HH:mm"))
+                                .font(.system(size: 18))
+                                .foregroundStyle(.gray)
+                        }
+                        
+                        Text(comment.text)
+                            .font(.system(size: 18))
+                            .foregroundStyle(.gray)
+                    }
+                    .padding(.vertical, 5)
                 }
             }
             .listStyle(.plain)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/PostView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/PostView.swift
@@ -70,15 +70,17 @@ struct PostView: View {
         .padding(.horizontal, 20)
         .frame(maxWidth: .infinity)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Menu {
-                    Button(role: .destructive) {
-                        showDeleteAlert = true
+            if viewModel.uid == viewModel.currentUser {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button(role: .destructive) {
+                            showDeleteAlert = true
+                        } label: {
+                            Label("삭제하기", systemImage: "trash")
+                        }
                     } label: {
-                        Label("삭제하기", systemImage: "trash")
+                        Image(systemName: "ellipsis")
                     }
-                } label: {
-                    Image(systemName: "ellipsis")
                 }
             }
         }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #65 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 본인이 작성한 게시물에만 삭제 버튼이 보이게 했습니다.
- 본인이 작성한 댓글만 삭제 버튼이 나타나게 했습니다.

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 댓글 삭제 방식은 추후 다른 pr에서 롱프레스 후 컨텍스트 메뉴 선택으로 변경할 예정입니다.
