### PR TITLE
feat: #132 FeedView 정렬 기능 구현

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -102,7 +102,6 @@
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
-		8B354C892EA4C6510030F9A1 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -120,6 +119,7 @@
 		8BDF768D2E9F498B007F12BB /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		8BDF76972E9F72CE007F12BB /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		8BDF769D2E9FDF88007F12BB /* GenerateCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCodeService.swift; sourceTree = "<group>"; };
+		8CAD89922EA52075004318F0 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CF9C7502EA129D400EB944A /* StickerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerSheetView.swift; sourceTree = "<group>"; };
 		8CF9C7A22EA148BC00EB944A /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		A192F2B02E9E45A800995DCC /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
@@ -334,6 +334,7 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
+				8CAD89922EA52075004318F0 /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -602,7 +603,7 @@
 				8B1EB7922EA07F7A00F720CF /* FirebaseAppCheck */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8B354C892EA4C6510030F9A1 /* DonDog-iOS.app */;
+			productReference = 8CAD89922EA52075004318F0 /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -532,16 +532,41 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         }
         
         group.notify(queue: .main) {
-            // 인덱스 순서대로 정렬하여 배열로 변환
-            let sortedPosts = tempDisplayablePosts.sorted(by: { $0.key < $1.key }).map { $0.value }
-            self.displayablePosts = sortedPosts
-            print("🎉 모든 게시물 기본 이미지 다운로드 완료: \(sortedPosts.count)개 (스티커는 별도 로딩)")
             
-            // 첫 번째 게시물을 현재 게시물로 설정
-            if let firstDisplayablePost = sortedPosts.first {
-                self.todayFrontImage = firstDisplayablePost.frontImage
-                self.todayBackImage = firstDisplayablePost.backImage
-                self.currentNickname = firstDisplayablePost.nickname
+            let sortedPosts = tempDisplayablePosts.sorted(by: { $0.key < $1.key }).map { $0.value }
+            
+            
+            let finalSortedPosts = sortedPosts.sorted { post1, post2 in
+                let hasSticker1 = !post1.stickerPostId.isEmpty
+                let hasSticker2 = !post2.stickerPostId.isEmpty
+                
+                
+                if hasSticker1 != hasSticker2 {
+                    return hasSticker1  // 스티커 있는게 왼쪽
+                }
+                
+                return post1.createdAt < post2.createdAt
+            }
+            
+            self.displayablePosts = finalSortedPosts
+            print("🎉 모든 게시물 기본 이미지 다운로드 완료: \(finalSortedPosts.count)개 (스티커는 별도 로딩)")
+            
+            // 🎯 스티커 없는 게시물 중 첫 번째 인덱스 찾기 (정렬 후 스티커 없는 것 중 가장 오래된 것)
+            let initialIndex = finalSortedPosts.firstIndex { post in
+                post.stickerPostId.isEmpty
+            } ?? 0  // 스티커 없는 게시물이 없으면 0번
+            
+            self.currentPostIndex = initialIndex
+            print("📍 초기 TabView 인덱스: \(initialIndex)")
+            
+            // 해당 인덱스의 게시물을 현재 게시물로 설정
+            if initialIndex < finalSortedPosts.count {
+                let initialPost = finalSortedPosts[initialIndex]
+                self.todayFrontImage = initialPost.frontImage
+                self.todayBackImage = initialPost.backImage
+                self.currentNickname = initialPost.nickname
+                self.selectedPostId = initialPost.postId
+                self.currentPost = initialPost.post
             }
         }
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #132 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 피드뷰 정렬기능을 구현했습니다
- 시간순으로 정렬된 [A(스티커O), B(스티커X, 오래됨), C(스티커O), D(스티커X, 최신), E(스티커X, 중간)]
 적용 후
- A(스티커O), C(스티커O), B(스티커X, 오래됨), E(스티커X, 중간), D(스티커X, 최신) 순으로 정렬
- FeedView 진입시 초기 인덱스는 B에 고정됩니다

---

