### PR TITLE
design: #141 디자이너 QA 반영

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchiveDetailView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchiveDetailView.swift
@@ -42,15 +42,6 @@ struct ArchiveDetailView: View {
                 )
                 .padding(.horizontal, 20)
                 
-                // 인디케이터
-                CustomPageIndicator(
-                    currentIndex: min(currentIndex + 1, max(viewModel.posts.count, 1)),
-                    totalCount: max(viewModel.posts.count, 1),
-                    backgroundColor: .ddGray100,
-                    textColor: .ddGray500
-                )
-                .padding(.vertical, 4)
-                
                 // 캐러셀
                 TabView(selection: $currentIndex) {
                     ForEach(Array(viewModel.posts.enumerated()), id: \.offset) { idx, post in
@@ -59,7 +50,9 @@ struct ArchiveDetailView: View {
                             userNameByUid: viewModel.userNameByUid,
                             onDelete: { comment in
                                 await viewModel.deleteComment(comment, from: post)
-                            }
+                            },
+                            currentIndex: currentIndex,
+                            totalCount: viewModel.posts.count
                         )
                         .tag(idx)
                     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/DetailCommentsView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/DetailCommentsView.swift
@@ -21,10 +21,12 @@ struct DetailCommentRow: View {
                     .font(.captionRegular13)
                     .foregroundStyle(.ddGray600)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             
             Text(comment.text)
                 .font(.captionRegular14)
                 .foregroundStyle(.ddBlack)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 20)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/DetailContentView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/DetailContentView.swift
@@ -11,9 +11,22 @@ struct DetailContentView: View {
     let post: ArchivePost
     let userNameByUid: [String: String]
     let onDelete: ((Comment) async -> Void)?
+    let currentIndex: Int
+    let totalCount: Int
     
     var body: some View {
         ScrollView {
+            // 인디케이터
+            if totalCount > 1 {
+                CustomPageIndicator(
+                    currentIndex: currentIndex + 1,
+                    totalCount: totalCount,
+                    backgroundColor: .ddGray100,
+                    textColor: .ddGray500
+                )
+                .padding(.vertical, 4)
+            }
+            
             // 폴라로이드 프레임
             ZStack {
                 VStack {


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #141

---

### 🧶 주요 변경 내용 (Summary)
- 댓글 열 롱탭 가능한 영역 수정
- CustomPageIndicator를 DetailContentView 스크롤 내부로 이동

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작

---

### 💬 기타 공유 사항
- 텍스트 없는 부분에서는 댓글 롱탭이 간헐적으로 작동하는데 이유를 모르겠어요 ㅠ.ㅠ PostView에도 반영해주세요!
---
