### PR TITLE
feat: #194 킹피셔 다운로드 후 1차로 피드뷰에 적용

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -115,7 +115,7 @@
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
-		8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -369,7 +369,6 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
-				8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};

--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		8B6E11912E9771EA0082B24C /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6E11902E9771EA0082B24C /* SettingViewModel.swift */; };
 		8B7377E02E9546030001EFCD /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7377DF2E9546030001EFCD /* AuthService.swift */; };
 		8B7729072EA73A3000344491 /* InWebSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7729062EA73A3000344491 /* InWebSheetView.swift */; };
-		8B822D792EAB565200D708D7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B822D782EAB565200D708D7 /* GoogleService-Info.plist */; };
 		8B822D7C2EAB617800D708D7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8B822D7B2EAB617800D708D7 /* Kingfisher */; };
 		8BA62EA42E9149A00054EB8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA62EA32E9149A00054EB8F /* AppDelegate.swift */; };
 		8BA7184B2E9DD7EC001F7857 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7184A2E9DD7EC001F7857 /* CustomButton.swift */; };
@@ -115,6 +114,7 @@
 		61C9B19F2E9BED150007C8F4 /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
+		8B2DBE432EACBFDC007776D4 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
@@ -125,7 +125,6 @@
 		8B6E11902E9771EA0082B24C /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		8B7377DF2E9546030001EFCD /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		8B7729062EA73A3000344491 /* InWebSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InWebSheetView.swift; sourceTree = "<group>"; };
-		8B822D782EAB565200D708D7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8BA62EA32E9149A00054EB8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BA7184A2E9DD7EC001F7857 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		8BA7184C2E9DE2C3001F7857 /* CustomTextfield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextfield.swift; sourceTree = "<group>"; };
@@ -135,7 +134,6 @@
 		8BDF768D2E9F498B007F12BB /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		8BDF76972E9F72CE007F12BB /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		8BDF769D2E9FDF88007F12BB /* GenerateCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCodeService.swift; sourceTree = "<group>"; };
-		8BE6FD832EACB8510063A8CD /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8BFC735E2EA5CB4800B54F03 /* NetworkErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorView.swift; sourceTree = "<group>"; };
 		8BFC73602EA5D18C00B54F03 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		8CAD89AF2EA62846004318F0 /* TextStrokeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStrokeUtils.swift; sourceTree = "<group>"; };
@@ -505,7 +503,6 @@
 			children = (
 				CA957C5C2E942B4200AEAB49 /* DonDog-iOS.entitlements */,
 				8B5F44592E90FF95003137F2 /* Info.plist */,
-				8B822D782EAB565200D708D7 /* GoogleService-Info.plist */,
 				CAA9AEBE2E8FC15C0047A89A /* App */,
 				CA957CEB2E98FC3D00AEAB49 /* Core */,
 				CAA9AED22E8FC15C0047A89A /* Presentation */,
@@ -650,7 +647,7 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8BE6FD832EACB8510063A8CD /* DonDog-iOS.app */;
+			productReference = 8B2DBE432EACBFDC007776D4 /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -703,7 +700,6 @@
 				CA957D012E98FCD700AEAB49 /* Pretendard-Regular.otf in Resources */,
 				CAA9AEE02E8FC15C0047A89A /* Assets.xcassets in Resources */,
 				CAA62D082EA205FC00C60E05 /* SejongGeulggot.otf in Resources */,
-				8B822D792EAB565200D708D7 /* GoogleService-Info.plist in Resources */,
 				CA957D072E99017400AEAB49 /* Colors.xcassets in Resources */,
 				8B1EB7972EA08E9800F720CF /* (null) in Resources */,
 			);

--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -114,8 +114,8 @@
 		61C9B19F2E9BED150007C8F4 /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
-		8B2DBE432EACBFDC007776D4 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
+		8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -369,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
+				8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -647,7 +648,7 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8B2DBE432EACBFDC007776D4 /* DonDog-iOS.app */;
+			productReference = 8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		8B6E11912E9771EA0082B24C /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6E11902E9771EA0082B24C /* SettingViewModel.swift */; };
 		8B7377E02E9546030001EFCD /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7377DF2E9546030001EFCD /* AuthService.swift */; };
 		8B7729072EA73A3000344491 /* InWebSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7729062EA73A3000344491 /* InWebSheetView.swift */; };
+		8B822D792EAB565200D708D7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B822D782EAB565200D708D7 /* GoogleService-Info.plist */; };
+		8B822D7C2EAB617800D708D7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8B822D7B2EAB617800D708D7 /* Kingfisher */; };
 		8BA62EA42E9149A00054EB8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA62EA32E9149A00054EB8F /* AppDelegate.swift */; };
 		8BA7184B2E9DD7EC001F7857 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7184A2E9DD7EC001F7857 /* CustomButton.swift */; };
 		8BA7184D2E9DE2C3001F7857 /* CustomTextfield.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7184C2E9DE2C3001F7857 /* CustomTextfield.swift */; };
@@ -114,7 +116,6 @@
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
-		8B58718F2EA8B13C00E5561C /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -124,6 +125,7 @@
 		8B6E11902E9771EA0082B24C /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		8B7377DF2E9546030001EFCD /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		8B7729062EA73A3000344491 /* InWebSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InWebSheetView.swift; sourceTree = "<group>"; };
+		8B822D782EAB565200D708D7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8BA62EA32E9149A00054EB8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BA7184A2E9DD7EC001F7857 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		8BA7184C2E9DE2C3001F7857 /* CustomTextfield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextfield.swift; sourceTree = "<group>"; };
@@ -133,12 +135,11 @@
 		8BDF768D2E9F498B007F12BB /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		8BDF76972E9F72CE007F12BB /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		8BDF769D2E9FDF88007F12BB /* GenerateCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCodeService.swift; sourceTree = "<group>"; };
+		8BE6FD832EACB8510063A8CD /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8BFC735E2EA5CB4800B54F03 /* NetworkErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorView.swift; sourceTree = "<group>"; };
 		8BFC73602EA5D18C00B54F03 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		8CAD89AF2EA62846004318F0 /* TextStrokeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStrokeUtils.swift; sourceTree = "<group>"; };
-		8CAD89D72EA9BFF6004318F0 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CAD89DA2EA9FD8D004318F0 /* HapticUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticUtils.swift; sourceTree = "<group>"; };
-		8CAD89CF2EA8B25C004318F0 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CF9C7502EA129D400EB944A /* StickerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerSheetView.swift; sourceTree = "<group>"; };
 		8CF9C7A22EA148BC00EB944A /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		A192F2B02E9E45A800995DCC /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
@@ -183,7 +184,6 @@
 		CAA9AEF12E8FE3070047A89A /* InviteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewModel.swift; sourceTree = "<group>"; };
 		CAACD3692EA0B8970057827D /* ArchiveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailView.swift; sourceTree = "<group>"; };
 		CAACD36B2EA0C1120057827D /* ArchiveDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailViewModel.swift; sourceTree = "<group>"; };
-		D219DDA32EA8B3B9009860BF /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D24402A12E992CCF00D837C8 /* CameraViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewContainer.swift; sourceTree = "<group>"; };
 		D24402A32E992CD800D837C8 /* CaptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionViewModel.swift; sourceTree = "<group>"; };
 		D24402A52E992CD800D837C8 /* CaptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionView.swift; sourceTree = "<group>"; };
@@ -204,6 +204,7 @@
 			files = (
 				8B3182782E90CE1B004505AE /* FirebaseMessaging in Frameworks */,
 				8B1EB7932EA07F7A00F720CF /* FirebaseAppCheck in Frameworks */,
+				8B822D7C2EAB617800D708D7 /* Kingfisher in Frameworks */,
 				8B3182722E90CE1B004505AE /* FirebaseDatabase in Frameworks */,
 				8B31827A2E90CE1B004505AE /* FirebasePerformance in Frameworks */,
 				8B31826A2E90CE1B004505AE /* FirebaseAnalytics in Frameworks */,
@@ -370,8 +371,6 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
-				8CAD89D72EA9BFF6004318F0 /* DonDog-iOS.app */,
-				8CAD89CF2EA8B25C004318F0 /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -506,6 +505,7 @@
 			children = (
 				CA957C5C2E942B4200AEAB49 /* DonDog-iOS.entitlements */,
 				8B5F44592E90FF95003137F2 /* Info.plist */,
+				8B822D782EAB565200D708D7 /* GoogleService-Info.plist */,
 				CAA9AEBE2E8FC15C0047A89A /* App */,
 				CA957CEB2E98FC3D00AEAB49 /* Core */,
 				CAA9AED22E8FC15C0047A89A /* Presentation */,
@@ -647,11 +647,10 @@
 				8B31827D2E90CE1B004505AE /* FirebaseStorage */,
 				8B31827F2E90CE1B004505AE /* FirebaseStorageCombine-Community */,
 				8B1EB7922EA07F7A00F720CF /* FirebaseAppCheck */,
+				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8CAD89D72EA9BFF6004318F0 /* DonDog-iOS.app */;
-			productReference = 8B58718F2EA8B13C00E5561C /* DonDog-iOS.app */;
-			productReference = 8CAD89CF2EA8B25C004318F0 /* DonDog-iOS.app */;
+			productReference = 8BE6FD832EACB8510063A8CD /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -680,6 +679,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				8B3182682E90CE1B004505AE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				8B822D7A2EAB617800D708D7 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CAA9AE772E8FBE250047A89A;
@@ -703,6 +703,7 @@
 				CA957D012E98FCD700AEAB49 /* Pretendard-Regular.otf in Resources */,
 				CAA9AEE02E8FC15C0047A89A /* Assets.xcassets in Resources */,
 				CAA62D082EA205FC00C60E05 /* SejongGeulggot.otf in Resources */,
+				8B822D792EAB565200D708D7 /* GoogleService-Info.plist in Resources */,
 				CA957D072E99017400AEAB49 /* Colors.xcassets in Resources */,
 				8B1EB7972EA08E9800F720CF /* (null) in Resources */,
 			);
@@ -1027,6 +1028,14 @@
 				minimumVersion = 12.3.0;
 			};
 		};
+		8B822D7A2EAB617800D708D7 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.6.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1094,6 +1103,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8B3182682E90CE1B004505AE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = "FirebaseStorageCombine-Community";
+		};
+		8B822D7B2EAB617800D708D7 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8B822D7A2EAB617800D708D7 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "originHash" : "bc240f009e1fa45c62a841709821f40ecac7be19de79cf2a8db25e79d8ea121b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -89,6 +89,15 @@
       "state" : {
         "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
         "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "dd3c422ec3088404d6f7e8c905a8318b3de12d6f",
+        "version" : "8.6.0"
       }
     },
     {

--- a/DonDog-iOS/DonDog-iOS/Core/Services/PhotoSaveService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/PhotoSaveService.swift
@@ -90,6 +90,7 @@ final class PhotoSaveService: ObservableObject {
         var uploadError: Error?
         
         group.enter()
+        
         uploadImage(image: frontImage, path: "rooms/\(roomId)/posts/\(postId)/front.jpg") { result in
             switch result {
             case .success(let url):
@@ -235,28 +236,24 @@ final class PhotoSaveService: ObservableObject {
             }
     }
     
-    func downloadImage(from urlString: String, completion: @escaping (Result<UIImage, Error>) -> Void) {
-        guard let url = URL(string: urlString) else {
-            completion(.failure(FirebaseError.invalidURL))
-            return
-        }
-        
-        URLSession.shared.dataTask(with: url) { data, response, error in
-            if let error = error {
-                completion(.failure(error))
-                return
-            }
-            
-            guard let data = data, let image = UIImage(data: data) else {
-                completion(.failure(FirebaseError.imageDownloadFailed))
-                return
-            }
-            
-            DispatchQueue.main.async {
-                completion(.success(image))
-            }
-        }.resume()
-    }
+    // url 이미지로 바꾸기
+//    func downloadImage(from url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
+//        URLSession.shared.dataTask(with: url) { data, response, error in
+//            if let error = error {
+//                completion(.failure(error))
+//                return
+//            }
+//            
+//            guard let data = data, let image = UIImage(data: data) else {
+//                completion(.failure(FirebaseError.imageDownloadFailed))
+//                return
+//            }
+//            
+//            DispatchQueue.main.async {
+//                completion(.success(image))
+//            }
+//        }.resume()
+//    }
     
     private func uploadImage(image: UIImage, path: String, completion: @escaping (Result<String, Error>) -> Void) {
         print("🚀 이미지 업로드 시작 - 경로: \(path)")

--- a/DonDog-iOS/DonDog-iOS/Presentation/Components/PolaroidSetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Components/PolaroidSetView.swift
@@ -6,9 +6,15 @@
 //
 
 import SwiftUI
+import Kingfisher
+
+enum DisplayableImage {
+    case url(URL)
+    case uiImage(UIImage)
+}
 
 struct PolaroidFrame: View {
-    let image: UIImage
+    let image: DisplayableImage
     let nickname: String
     let createdAt: String
     let caption: String?
@@ -18,20 +24,32 @@ struct PolaroidFrame: View {
     let stickerImage: UIImage?
     let isMyPost: Bool?
     
+    @ViewBuilder
+    private func imageView(_ source: DisplayableImage) -> some View {
+        switch source {
+        case .url(let url):
+            KFImage(url)
+                .resizable()
+                .scaledToFit()
+        case .uiImage(let img):
+            Image(uiImage: img)
+                .resizable()
+                .scaledToFit()
+        }
+    }
+    
     private var stickerDecoString: String {
         guard let stickerEmotion = StickerEmotion(rawValue: selectedStickerEmotion ?? "") else {
-                return ""
-            }
-            return stickerEmotion.stickerDecoString
+            return ""
         }
+        return stickerEmotion.stickerDecoString
+    }
     
     var body: some View {
         ZStack{
             VStack(spacing: 0) {
                 Spacer()
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
+                imageView(image)
                     .cornerRadius(3)
                     .shadow(color: Color.black.opacity(0.15), radius: 3, x: 1, y: 2)
                     .frame(width: 240, height: 320)
@@ -97,8 +115,8 @@ struct PolaroidFrame: View {
 struct PolaroidSetView: View {
     @State var isTopImage = true
     
-    let frontImage: UIImage
-    let backImage: UIImage
+    let frontImage: DisplayableImage
+    let backImage: DisplayableImage
     let nickname: String
     let createdAt: String
     let caption: String?
@@ -147,15 +165,15 @@ struct PolaroidSetView: View {
     }
 }
 
-#Preview(body: {
-    PolaroidSetView(
-        frontImage: UIImage(named: "test1")!,
-        backImage: UIImage(named: "test2")!,
-        nickname: "이토",
-        createdAt: "오전 04:45",
-        caption: "하이디라오 짱맛",
-        selectedStickerEmotion: "사랑해",
-        stickerImage: UIImage(named: "frontTest")!,
-        isMyPost: false  // Preview에서는 다른 사람 게시물로 설정
-    )
-})
+//#Preview(body: {
+//    PolaroidSetView(
+//        frontImage: UIImage(named: "test1")!,
+//        backImage: UIImage(named: "test2")!,
+//        nickname: "이토",
+//        createdAt: "오전 04:45",
+//        caption: "하이디라오 짱맛",
+//        selectedStickerEmotion: "사랑해",
+//        stickerImage: UIImage(named: "frontTest")!,
+//        isMyPost: false  // Preview에서는 다른 사람 게시물로 설정
+//    )
+//})

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/ViewModels/ArchiveStickerViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/ViewModels/ArchiveStickerViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 import UIKit
+import Kingfisher
 
 final class ArchiveStickerViewModel: ObservableObject {
     let roomId: String
@@ -41,7 +42,7 @@ final class ArchiveStickerViewModel: ObservableObject {
         }
         
         let stickerPostRef = db.collection("Rooms").document(roomId).collection("posts").document(stickerPostId)
-        stickerPostRef.getDocument { [weak self] stickerSnapshot, error in
+        stickerPostRef.getDocument(source: .default) { [weak self] stickerSnapshot, error in
             guard let self = self else { return }
             if let error = error {
                 print("스티커용 post 조회 실패:", error.localizedDescription)
@@ -56,7 +57,7 @@ final class ArchiveStickerViewModel: ObservableObject {
             }
             
             let postRef = self.db.collection("Rooms").document(self.roomId).collection("posts").document(postId)
-            postRef.getDocument { postSnapshot, postError in
+            postRef.getDocument(source: .default) { postSnapshot, postError in
                 if let postError = postError {
                     print("현재 postId \(postId) 조회 실패:", postError.localizedDescription)
                     return
@@ -69,26 +70,34 @@ final class ArchiveStickerViewModel: ObservableObject {
                     return
                 }
                 
-                PhotoSaveService.shared.downloadImage(from: imageUrlString) { result in
+                guard let url = URL(string: imageUrlString) else {
+                    print("스티커 이미지 URL 변환 실패")
+                    return
+                }
+                
+                KingfisherManager.shared.retrieveImage(with: url) { result in
                     switch result {
-                    case .success(let image):
+                    case .success(let value):
+                        let image = value.image
+                        let utils = ImageUtils()
+                        let borderColor = self.borderColor(for: emotion)
+                        
                         DispatchQueue.global(qos: .userInitiated).async {
-                            guard let stickerOnly = self.imageUtils.makeSticker(with: image) else {
+                            guard let stickerOnly = utils.makeSticker(with: image) else {
                                 print("스티커 생성 실패")
                                 return
                             }
                             
-                            let borderedSticker = stickerOnly.addBorder(
-                                thickness: 50,
-                                color: self.borderColor(for: emotion)
-                            )
+                            let resultImage = stickerOnly.addBorder(thickness: 50, color: borderColor) ?? stickerOnly
+                            
                             DispatchQueue.main.async {
-                                self.borderedStickers[postId] = borderedSticker
+                                self.borderedStickers[postId] = resultImage
                                 self.emotions[postId] = emotion
                             }
                         }
+                        
                     case .failure(let error):
-                        print("스티커 이미지 다운로드 실패:", error.localizedDescription)
+                        print("KF 스티커 이미지 불러오기 실패:", error.localizedDescription)
                     }
                 }
             }
@@ -112,4 +121,3 @@ final class ArchiveStickerViewModel: ObservableObject {
         }
     }
 }
-

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CameraViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/ViewModels/CameraViewModel.swift
@@ -9,7 +9,6 @@ import Combine
 import SwiftUI
 import UIKit
 
-
 protocol CameraViewModelDelegate: AnyObject {
     func didCaptureImages(frontImage: UIImage, backImage: UIImage)
     func didUploadToRoomPosts(postData: PostData)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/ViewModels/CaptionViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/ViewModels/CaptionViewModel.swift
@@ -28,7 +28,7 @@ final class CaptionViewModel: ObservableObject {
         self.backImage = backImage
     }
     
-    func uploadPost() {
+    func uploadPost(onSuccess: @escaping () -> Void) {
         guard let frontImage = frontImage, let backImage = backImage else {
             print("❌ 전면 또는 후면 이미지가 없습니다")
             return
@@ -50,6 +50,7 @@ final class CaptionViewModel: ObservableObject {
                     print("✅ 업로드 성공: \(postData.uid)")
                     print("📝 캡션: \(postData.caption)")
                     self?.delegate?.didUploadPost()
+                    onSuccess()
                 case .failure(let error):
                     print("❌ 업로드 실패: \(error.localizedDescription)")
                 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -73,8 +73,9 @@ struct CaptionView: View {
                     .frame(height: 20)
                 
                 Button{
-                    viewModel.uploadPost()
-                    onUploadComplete()
+                    viewModel.uploadPost {
+                        onUploadComplete() // 업로드 성공 뒤 실행
+                    }
                 }label: {
                         Text("업로드")
                             .font(.bodyRegular18)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -33,7 +33,7 @@ struct CaptionView: View {
                     if let frontImage = viewModel.frontImage, let backImage = viewModel.backImage {
                         HStack{
                             Spacer()
-                            PolaroidSetView(frontImage: frontImage, backImage: backImage, nickname: "", createdAt: "", caption: nil,  selectedStickerEmotion: nil, stickerImage: nil, isMyPost: true)
+                            PolaroidSetView(frontImage: .uiImage(frontImage), backImage: .uiImage(backImage), nickname: "", createdAt: "", caption: nil,  selectedStickerEmotion: nil, stickerImage: nil, isMyPost: true)
                                 .allowsHitTesting(true)
                                 .padding(.trailing, 30)
                         }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Models/PostData.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Models/PostData.swift
@@ -29,8 +29,12 @@ struct PostData: Codable {
         self.updatedAt = Timestamp()
         self.stickerPostId = stickerPostId
         self.stickerType = stickerType
-        
     }
+}
+
+extension PostData {
+    var frontURL: URL? { URL(string: frontImageURL) }
+    var backURL: URL?  { URL(string: backImageURL) }
 }
 
 // MARK: - DisplayablePost
@@ -38,17 +42,17 @@ struct PostData: Codable {
 struct DisplayablePost: Identifiable {
     let id: String  // postId
     let post: PostData
-    var frontImage: UIImage?
-    var backImage: UIImage?
+    var frontImageURL: URL? = nil
+    var backImageURL: URL? = nil
     var stickerImage: UIImage?  // 이 게시물에 붙은 스티커 이미지
     var nickname: String
     let isMyPost: Bool  // 내 게시물인지 여부
     
-    init(post: PostData, frontImage: UIImage? = nil, backImage: UIImage? = nil, stickerImage: UIImage? = nil, nickname: String = "익명", isMyPost: Bool = false) {
+    init(post: PostData, frontImage: URL? = nil, backImage: URL? = nil, stickerImage: UIImage? = nil, nickname: String = "익명", isMyPost: Bool = false) {
         self.id = post.postId
         self.post = post
-        self.frontImage = frontImage
-        self.backImage = backImage
+        self.frontImageURL = frontImage
+        self.backImageURL = backImage
         self.stickerImage = stickerImage
         self.nickname = nickname
         self.isMyPost = isMyPost
@@ -64,6 +68,6 @@ struct DisplayablePost: Identifiable {
     
     // 이미지가 모두 다운로드되었는지 확인
     var isReady: Bool {
-        frontImage != nil && backImage != nil
+        frontImageURL != nil && backImageURL != nil
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -6,12 +6,12 @@
 //
 
 import Combine
-import UIKit
-import FirebaseAuth
-import FirebaseFirestore
 import CoreImage
 import CoreImage.CIFilterBuiltins
+import FirebaseAuth
+import FirebaseFirestore
 import Kingfisher
+import UIKit
 
 final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionViewModelDelegate {
     @Published var selectedFrontImage: UIImage?
@@ -32,12 +32,12 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         }
     }
     
-    @Published var stickerImage: UIImage? // 원본 사진
-    @Published var sticker: UIImage? // 누끼따진 스티커
+    @Published var stickerImage: UIImage?
+    @Published var sticker: UIImage?
     @Published var myNickname: String = ""
     private var mask: UIImage?
     @Published var frame: UIImage?
-    @Published var borderedStickers: [String: UIImage] = [:] // 테두리까지 씌워진 스티커 스티커
+    @Published var borderedStickers: [String: UIImage] = [:]
     
     @Published var currentPost: PostData?
     @Published var currentNickname: String = ""
@@ -63,10 +63,9 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             }
         }
         loadTodayPosts()
-        self.getStickerData() // 스티커 재료를 가져옴 (users의 recentPostId를 가져와 rooms에서 전면 사진을 가져옴)
+        self.getStickerData()
     }
     
-    // 내 게시물인지 확인
     func checkIsNotMyPost() {
         guard !currentRoomId.isEmpty, !selectedPostId.isEmpty else {
             print("currentRoomId 또는 selectedPostId가 비어 있음")

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -11,6 +11,7 @@ import FirebaseAuth
 import FirebaseFirestore
 import CoreImage
 import CoreImage.CIFilterBuiltins
+import Kingfisher
 
 final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionViewModelDelegate {
     @Published var selectedFrontImage: UIImage?
@@ -18,8 +19,8 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
     @Published var postsList: [PostData] = []
     @Published var images: [PostData] = []
     @Published var todayPost: PostData?
-    @Published var todayFrontImage: UIImage?
-    @Published var todayBackImage: UIImage?
+    @Published var todayFrontImageURL: URL?
+    @Published var todayBackImageURL: URL?
     @Published var isLoading = false
     @Published var isUploading = false
     @Published var isAfterUpload = false
@@ -31,12 +32,12 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         }
     }
     
-    @Published var stickerImage: UIImage?
-    @Published var sticker: UIImage?
+    @Published var stickerImage: UIImage? // 원본 사진
+    @Published var sticker: UIImage? // 누끼따진 스티커
     @Published var myNickname: String = ""
     private var mask: UIImage?
     @Published var frame: UIImage?
-    @Published var borderedStickers: [String: UIImage] = [:]
+    @Published var borderedStickers: [String: UIImage] = [:] // 테두리까지 씌워진 스티커 스티커
     
     @Published var currentPost: PostData?
     @Published var currentNickname: String = ""
@@ -65,6 +66,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         self.getStickerData()
     }
     
+    // 내 게시물인지 확인
     func checkIsNotMyPost() {
         guard !currentRoomId.isEmpty, !selectedPostId.isEmpty else {
             print("currentRoomId 또는 selectedPostId가 비어 있음")
@@ -75,32 +77,33 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             .document(currentRoomId)
             .collection("posts")
             .document(selectedPostId)
-
+        
         postRef.getDocument { snapshot, error in
             if let error = error {
                 print("문서 조회 실패: \(error.localizedDescription)")
                 return
             }
-
+            
             guard let data = snapshot?.data(),
                   let uid = data["uid"] as? String,
                   let currentUid = Auth.auth().currentUser?.uid else {
                 return
             }
-
+            
             self.isNotMyPost = uid != currentUid
         }
     }
     
+    // 서버에서 원본 이미지 가져오고, 누끼따고, 씌우기
     func getStickerData() {
         guard let uid = Auth.auth().currentUser?.uid else { return }
-
-        db.collection("Users").document(uid).getDocument { [weak self] snapshot, error in
+        
+        db.collection("Users").document(uid).getDocument(source: .default) { [weak self] snapshot, error in
             if let error = error {
                 print("recentPostId 불러오기 실패: \(error.localizedDescription)")
                 return
             }
-
+            
             guard
                 let self = self,
                 let data = snapshot?.data(),
@@ -137,7 +140,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                     
                     let postRef = basePostRef.document(postIdToFetch)
                     
-                    postRef.getDocument { snapshot, error in
+                    postRef.getDocument(source: .default) { snapshot, error in
                         if let error = error {
                             print("sticker로 쓸 postId 문서 조회 실패: \(error.localizedDescription)")
                             return
@@ -151,18 +154,20 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                             return
                         }
                         
-                        PhotoSaveService.shared.downloadImage(from: imageUrlString) { [weak self] result in
-                            switch result {
-                            case .success(let image):
-                                DispatchQueue.main.async {
-                                    self?.stickerImage = image
-                                    print("recentSticker 이미지 로드 성공")
-                                    
-                                    self?.makeStickerAndBordered(from: image)
-                                    self?.emotion = postData["stickerType"] as? String ?? "null"
+                        self.downloadStickerImage(
+                            stickerPostId: postIdToFetch,
+                            roomId: roomId,
+                            stickerType: postData["stickerType"] as? String
+                        ) { [weak self] sticker in
+                            DispatchQueue.main.async {
+                                if let sticker = sticker {
+                                    self?.stickerImage = sticker
+                                    self?.sticker = sticker
+                                    print("recentSticker 이미지 로드 성공 (downloadStickerImage)")
+                                } else {
+                                    print("recentSticker 이미지 생성 실패")
                                 }
-                            case .failure(let error):
-                                print("이미지 다운로드 실패: \(error.localizedDescription)")
+                                self?.emotion = postData["stickerType"] as? String ?? "null"
                             }
                         }
                     }
@@ -189,7 +194,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             var borderedDict: [String: UIImage] = [:]
             
             for emotion in emotions {
-                let color = self.borderColor(for: emotion)
+                let color = FeedViewModel.borderColor(for: emotion)
                 if let bordered = stickerOnly.addBorder(thickness: 50, color: color) {
                     borderedDict[emotion] = bordered
                 }
@@ -207,7 +212,6 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         return borderedStickers[emotion] ?? sticker
     }
     
-    
     func updateStickerData() {
         guard !currentRoomId.isEmpty, !selectedPostId.isEmpty else {
             print("currentRoomId 또는 selectedPostId가 비어 있어 업데이트 불가")
@@ -216,7 +220,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         
         guard let currentUid = Auth.auth().currentUser?.uid else { return }
         
-        db.collection("Users").document(currentUid).getDocument { [weak self] snapshot, error in
+        db.collection("Users").document(currentUid).getDocument(source: .default) { [weak self] snapshot, error in
             guard let self = self,
                   let data = snapshot?.data(),
                   let recentPostId = data["recentPostId"] as? String else {
@@ -244,38 +248,36 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                     return
                 }
                 
-                postRef.getDocument { snapshot, error in
+                postRef.getDocument(source: .default) { snapshot, error in
                     if let data = snapshot?.data() {
                         let stickerPostId = data["stickerPostId"] as? String ?? recentPostId
                         
                         self.downloadStickerImage(stickerPostId: stickerPostId, roomId: self.currentRoomId, stickerType: self.emotion) { stickerImage in
-                            DispatchQueue.main.async {
-                                guard let index = self.displayablePosts.firstIndex(where: { $0.postId == self.selectedPostId }) else {
-                                    print("게시물을 찾을 수 없습니다")
-                                    return
-                                }
-                                
-                                let existingPost = self.displayablePosts[index]
-                                let newPostData = PostData(
-                                    postId: existingPost.postId,
-                                    uid: existingPost.uid,
-                                    frontImageURL: existingPost.post.frontImageURL,
-                                    backImageURL: existingPost.post.backImageURL,
-                                    caption: existingPost.caption,
-                                    createdAt: existingPost.post.createdAt,
-                                    stickerPostId: recentPostId,
-                                    stickerType: self.emotion
-                                )
-                                
-                                self.displayablePosts[index] = DisplayablePost(
-                                    post: newPostData,
-                                    frontImage: existingPost.frontImage,
-                                    backImage: existingPost.backImage,
-                                    stickerImage: stickerImage,
-                                    nickname: existingPost.nickname,
-                                    isMyPost: existingPost.isMyPost
-                                )
+                            guard let index = self.displayablePosts.firstIndex(where: { $0.postId == self.selectedPostId }) else {
+                                print("게시물을 찾을 수 없습니다")
+                                return
                             }
+                            
+                            let existingPost = self.displayablePosts[index]
+                            let newPostData = PostData(
+                                postId: existingPost.postId,
+                                uid: existingPost.uid,
+                                frontImageURL: existingPost.post.frontImageURL,
+                                backImageURL: existingPost.post.backImageURL,
+                                caption: existingPost.caption,
+                                createdAt: existingPost.post.createdAt,
+                                stickerPostId: recentPostId,
+                                stickerType: self.emotion
+                            )
+                            
+                            self.displayablePosts[index] = DisplayablePost(
+                                post: newPostData,
+                                frontImage: existingPost.frontImageURL,
+                                backImage: existingPost.backImageURL,
+                                stickerImage: stickerImage,
+                                nickname: existingPost.nickname,
+                                isMyPost: existingPost.isMyPost
+                            )
                         }
                     }
                 }
@@ -311,42 +313,40 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             
             print("✅ Firestore 스티커 삭제 완료: \(self.selectedPostId)")
             
-            DispatchQueue.main.async {
-                guard let index = self.displayablePosts.firstIndex(where: { $0.postId == self.selectedPostId }) else {
-                    print("⚠️ 게시물을 찾을 수 없습니다")
-                    return
-                }
-                
-                let existingPost = self.displayablePosts[index]
-                let newPostData = PostData(
-                    postId: existingPost.postId,
-                    uid: existingPost.uid,
-                    frontImageURL: existingPost.post.frontImageURL,
-                    backImageURL: existingPost.post.backImageURL,
-                    caption: existingPost.caption,
-                    createdAt: existingPost.post.createdAt,
-                    stickerPostId: "",
-                    stickerType: nil
-                )
-                
-                self.displayablePosts[index] = DisplayablePost(
-                    post: newPostData,
-                    frontImage: existingPost.frontImage,
-                    backImage: existingPost.backImage,
-                    stickerImage: nil,
-                    nickname: existingPost.nickname,
-                    isMyPost: existingPost.isMyPost
-                )
-                print("✅ 로컬 UI 업데이트 완료: 스티커 제거됨")
+            guard let index = self.displayablePosts.firstIndex(where: { $0.postId == self.selectedPostId }) else {
+                print("⚠️ 게시물을 찾을 수 없습니다")
+                return
             }
+            
+            let existingPost = self.displayablePosts[index]
+            let newPostData = PostData(
+                postId: existingPost.postId,
+                uid: existingPost.uid,
+                frontImageURL: existingPost.post.frontImageURL,
+                backImageURL: existingPost.post.backImageURL,
+                caption: existingPost.caption,
+                createdAt: existingPost.post.createdAt,
+                stickerPostId: "",
+                stickerType: nil
+            )
+            
+            self.displayablePosts[index] = DisplayablePost(
+                post: newPostData,
+                frontImage: existingPost.frontImageURL,
+                backImage: existingPost.backImageURL,
+                stickerImage: nil,
+                nickname: existingPost.nickname,
+                isMyPost: existingPost.isMyPost
+            )
+            print("✅ 로컬 UI 업데이트 완료: 스티커 제거됨")
         }
     }
     
+    // MARK: - CaptionViewModelDelegate
     func didCaptureImages(frontImage: UIImage, backImage: UIImage) {
         selectedFrontImage = frontImage
         selectedBackImage = backImage
     }
-    
     
     func didUploadToRoomPosts(postData: PostData) {
         uploadStatus = "Room posts 업로드 완료: \(postData.uid)"
@@ -356,8 +356,6 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             self.uploadStatus = ""
         }
     }
-    
-    // MARK: - CaptionViewModelDelegate
     
     func didUploadPost() {
         print("✅ 게시물 업로드 완료 - FeedView 새로고침")
@@ -440,32 +438,9 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         let group = DispatchGroup()
         
         group.enter()
-        photoSaveService.downloadImage(from: post.frontImageURL) { [weak self] result in
-            switch result {
-            case .success(let image):
-                DispatchQueue.main.async {
-                    self?.todayFrontImage = image
-                    print("✅ 전면 이미지 다운로드 성공")
-                }
-            case .failure(let error):
-                print("❌ 전면 이미지 다운로드 실패: \(error.localizedDescription)")
-            }
-            group.leave()
-        }
         
-        group.enter()
-        photoSaveService.downloadImage(from: post.backImageURL) { [weak self] result in
-            switch result {
-            case .success(let image):
-                DispatchQueue.main.async {
-                    self?.todayBackImage = image
-                    print("✅ 후면 이미지 다운로드 성공")
-                }
-            case .failure(let error):
-                print("❌ 후면 이미지 다운로드 실패: \(error.localizedDescription)")
-            }
-            group.leave()
-        }
+        self.todayFrontImageURL = post.frontURL
+        self.todayBackImageURL  = post.backURL
         
         group.notify(queue: .main) {
             print("🎉 오늘 이미지 다운로드 완료")
@@ -487,31 +462,12 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             let isMyPost = (post.uid == currentUserUid)
             let imageGroup = DispatchGroup()
             
-            var frontImage: UIImage?
-            var backImage: UIImage?
+            var frontImageURL: URL? = nil
+            var backImageURL: URL? = nil
             var nickname: String = "익명"
             
-            imageGroup.enter()
-            photoSaveService.downloadImage(from: post.frontImageURL) { result in
-                switch result {
-                case .success(let image):
-                    frontImage = image
-                case .failure(let error):
-                    print("❌ 전면 이미지 다운로드 실패: \(error.localizedDescription)")
-                }
-                imageGroup.leave()
-            }
-            
-            imageGroup.enter()
-            photoSaveService.downloadImage(from: post.backImageURL) { result in
-                switch result {
-                case .success(let image):
-                    backImage = image
-                case .failure(let error):
-                    print("❌ 후면 이미지 다운로드 실패: \(error.localizedDescription)")
-                }
-                imageGroup.leave()
-            }
+            frontImageURL = post.frontURL
+            backImageURL = post.backURL
             
             imageGroup.enter()
             getUserName(uid: post.uid) { name in
@@ -520,7 +476,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             }
             
             imageGroup.notify(queue: .main) {
-                if let front = frontImage, let back = backImage {
+                if let front = frontImageURL, let back = backImageURL {
                     let displayablePost = DisplayablePost(
                         post: post,
                         frontImage: front,
@@ -541,8 +497,8 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                                 if let idx = self.displayablePosts.firstIndex(where: { $0.postId == post.postId }) {
                                     let updatedPost = DisplayablePost(
                                         post: self.displayablePosts[idx].post,
-                                        frontImage: self.displayablePosts[idx].frontImage,
-                                        backImage: self.displayablePosts[idx].backImage,
+                                        frontImage: self.displayablePosts[idx].frontImageURL,
+                                        backImage: self.displayablePosts[idx].backImageURL,
                                         stickerImage: sticker,
                                         nickname: self.displayablePosts[idx].nickname,
                                         isMyPost: self.displayablePosts[idx].isMyPost
@@ -580,8 +536,8 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             
             if !finalSortedPosts.isEmpty {
                 let initialPost = finalSortedPosts[firstDisplayedPostIndex]
-                self.todayFrontImage = initialPost.frontImage
-                self.todayBackImage = initialPost.backImage
+                self.todayFrontImageURL = initialPost.frontImageURL
+                self.todayBackImageURL  = initialPost.backImageURL
                 self.currentNickname = initialPost.nickname
                 self.selectedPostId = initialPost.postId
                 self.currentPost = initialPost.post
@@ -605,8 +561,8 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                             // 로컬 배열에 업데이트
                             postsWithStickers[index] = DisplayablePost(
                                 post: postsWithStickers[index].post,
-                                frontImage: postsWithStickers[index].frontImage,
-                                backImage: postsWithStickers[index].backImage,
+                                frontImage: postsWithStickers[index].frontImageURL,
+                                backImage: postsWithStickers[index].backImageURL,
                                 stickerImage: sticker,
                                 nickname: postsWithStickers[index].nickname,
                                 isMyPost: postsWithStickers[index].isMyPost
@@ -626,10 +582,10 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                 print("✅ 로딩 완료!")
                 
                 if self.isAfterUpload && self.displayablePosts.count > 1 && self.currentPostIndex == 1 {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                                self.currentPostIndex = 0
-                            self.isAfterUpload = false
-                        }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                        self.currentPostIndex = 0
+                        self.isAfterUpload = false
+                    }
                 } else {
                     self.isAfterUpload = false
                 }
@@ -661,7 +617,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             .document(roomId)
             .collection("posts")
             .document(stickerPostId)
-            .getDocument { [weak self] snapshot, error in
+            .getDocument(source: .default) { [weak self] snapshot, error in
                 guard let self = self else {
                     completion(nil)
                     return
@@ -680,9 +636,16 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                     return
                 }
                 
-                self.photoSaveService.downloadImage(from: frontImageURL) { result in
+                guard let url = URL(string: frontImageURL) else {
+                    print("스티커 이미지 URL 생성 실패")
+                    completion(nil)
+                    return
+                }
+                
+                KingfisherManager.shared.retrieveImage(with: url) { result in
                     switch result {
-                    case .success(let image):
+                    case .success(let value):
+                        let image = value.image
                         DispatchQueue.global(qos: .userInitiated).async {
                             let utils = ImageUtils()
                             
@@ -693,9 +656,9 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                                 DispatchQueue.main.async { completion(nil) }
                                 return
                             }
-
+                            
                             if let emotion = stickerType {
-                                let borderColor = self.borderColor(for: emotion)
+                                let borderColor = FeedViewModel.borderColor(for: emotion)
                                 if let borderedSticker = stickerOnly.addBorder(thickness: 50, color: borderColor) {
                                     DispatchQueue.main.async {
                                         completion(borderedSticker)
@@ -705,13 +668,13 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                                     print("테두리 추가 실패, 기본 스티커 반환")
                                 }
                             }
-
+                            
                             DispatchQueue.main.async {
                                 completion(stickerOnly)
                             }
                         }
                     case .failure(let error):
-                        print("스티커 이미지 다운로드 실패: \(error.localizedDescription)")
+                        print("KF 스티커 이미지 조회 실패: \(error.localizedDescription)")
                         completion(nil)
                     }
                 }
@@ -734,7 +697,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         return colorFilter.outputImage
     }
     
-    private func borderColor(for emotion: String) -> UIColor {
+    static func borderColor(for emotion: String) -> UIColor {
         switch emotion {
         case "사랑해":
             return .ddFeelingPink
@@ -785,9 +748,8 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         currentPostIndex = index
         currentPost = displayablePost.post
         selectedPostId = displayablePost.postId
-        todayFrontImage = displayablePost.frontImage
-        todayBackImage = displayablePost.backImage
+        todayFrontImageURL = displayablePost.frontImageURL
+        todayBackImageURL  = displayablePost.backImageURL
         currentNickname = displayablePost.nickname
     }
 }
-

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -338,12 +338,12 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         }
     }
     
-    // MARK: - CaptionViewModelDelegate
     func didCaptureImages(frontImage: UIImage, backImage: UIImage) {
         selectedFrontImage = frontImage
         selectedBackImage = backImage
     }
     
+
     func didUploadToRoomPosts(postData: PostData) {
         uploadStatus = "Room posts 업로드 완료: \(postData.uid)"
         loadTodayPosts()
@@ -353,6 +353,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         }
     }
     
+    // MARK: - CaptionViewModelDelegate
     func didUploadPost() {
         print("✅ 게시물 업로드 완료 - FeedView 새로고침")
         

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -63,7 +63,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
             }
         }
         loadTodayPosts()
-        self.getStickerData()
+        self.getStickerData() // 스티커 재료를 가져옴 (users의 recentPostId를 가져와 rooms에서 전면 사진을 가져옴)
     }
     
     // 내 게시물인지 확인
@@ -146,10 +146,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                             return
                         }
                         
-                        guard
-                            let postData = snapshot?.data(),
-                            let imageUrlString = postData["frontImageURL"] as? String
-                        else {
+                        guard let postData = snapshot?.data() else {
                             print("frontImageURL 없음")
                             return
                         }
@@ -162,7 +159,7 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
                             DispatchQueue.main.async {
                                 if let sticker = sticker {
                                     self?.stickerImage = sticker
-                                    self?.sticker = sticker
+                                    self?.makeStickerAndBordered(from: sticker)
                                     print("recentSticker 이미지 로드 성공 (downloadStickerImage)")
                                 } else {
                                     print("recentSticker 이미지 생성 실패")

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/PostViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/PostViewModel.swift
@@ -9,6 +9,7 @@ import Combine
 import FirebaseAuth
 import FirebaseFirestore
 import FirebaseStorage
+import Kingfisher
 
 final class PostViewModel: ObservableObject {
     let postId: String
@@ -61,7 +62,7 @@ final class PostViewModel: ObservableObject {
         guard !roomId.isEmpty, !stickerPostId.isEmpty else { return }
         
         let stickerPostRef = db.collection("Rooms").document(roomId).collection("posts").document(self.stickerPostId)
-        stickerPostRef.getDocument { [weak self] stickerSnapshot, error in
+        stickerPostRef.getDocument(source: .default) { [weak self] stickerSnapshot, error in
             guard let self = self else { return }
             if let error = error {
                 print("스티커용 post 조회 실패:", error.localizedDescription)
@@ -76,7 +77,7 @@ final class PostViewModel: ObservableObject {
             }
             
             let postRef = self.db.collection("Rooms").document(self.roomId).collection("posts").document(self.postId)
-            postRef.getDocument { postSnapshot, postError in
+            postRef.getDocument(source: .default) { postSnapshot, postError in
                 if let postError = postError {
                     print("현재 postId \(self.postId) 조회 실패:", postError.localizedDescription)
                     return
@@ -89,26 +90,43 @@ final class PostViewModel: ObservableObject {
                     return
                 }
                 
-                PhotoSaveService.shared.downloadImage(from: imageUrlString) { result in
+                guard let url = URL(string: imageUrlString) else {
+                    print("스티커 이미지 URL 생성 실패")
+                    return
+                }
+                
+                // KF 캐시 우선 조회 후 네트워크 폴백
+                KingfisherManager.shared.retrieveImage(with: url) { result in
                     switch result {
-                    case .success(let image):
+                    case .success(let value):
+                        let image = value.image
+                        
+                        // @Sendable 클로저 내부에서 self 캡처를 줄이기 위해 미리 색상을 계산
+                        let borderColor = self.borderColor(for: emotion)
+                        let utils = self.imageUtils
+                        
                         DispatchQueue.global(qos: .userInitiated).async {
-                            guard let stickerOnly = self.imageUtils.makeSticker(with: image) else {
+                            guard let stickerOnly = utils.makeSticker(with: image) else {
                                 print("스티커 생성 실패")
+                                DispatchQueue.main.async { self.borderedSticker = UIImage() }
                                 return
                             }
                             
-                            let borderedSticker = stickerOnly.addBorder(
-                                thickness: 50,
-                                color: self.borderColor(for: emotion)
-                            )
+                            let resultImage: UIImage
+                            if let bordered = stickerOnly.addBorder(thickness: 50, color: borderColor) {
+                                resultImage = bordered
+                            } else {
+                                print("테두리 추가 실패, 기본 스티커 반환")
+                                resultImage = stickerOnly
+                            }
+                            
                             DispatchQueue.main.async {
-                                self.borderedSticker = borderedSticker ?? UIImage()
+                                self.borderedSticker = resultImage
                                 self.emotion = emotion
                             }
                         }
                     case .failure(let error):
-                        print("스티커 이미지 다운로드 실패:", error.localizedDescription)
+                        print("KF 스티커 이미지 조회 실패:", error.localizedDescription)
                     }
                 }
             }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -9,7 +9,6 @@ import FirebaseAuth
 import PhotosUI
 import SwiftUI
 import UIKit
-import FirebaseCore
 
 struct FeedView: View {
     @EnvironmentObject var coordinator: AppCoordinator
@@ -44,6 +43,7 @@ struct FeedView: View {
                         }
                     }
                 }
+                
                 HStack {
                     Spacer()
                     if !viewModel.displayablePosts.isEmpty && !viewModel.isUploading {
@@ -78,7 +78,7 @@ struct FeedView: View {
                             .foregroundStyle(.ddPrimaryBlue)
                     }
                     .padding(.top, 280)
-                }else if connectState.isConnected == false {
+                } else if connectState.isConnected == false {
                     VStack{
                         Spacer()
                         Image(systemName: "person.fill.xmark")
@@ -108,14 +108,14 @@ struct FeedView: View {
                 }  else if !viewModel.displayablePosts.isEmpty {
                     ZStack{
                         TabView(selection: $viewModel.currentPostIndex) {
-                            ForEach(Array(viewModel.displayablePosts.enumerated()), id: \.element.id) { index, displayablePost in
-                                if let frontImage = displayablePost.frontImage,
-                                   let backImage = displayablePost.backImage {
+                            ForEach(Array(viewModel.displayablePosts.indices), id: \.self) { index in
+                                let displayablePost = viewModel.displayablePosts[index]
+                                if let front = displayablePost.frontImageURL, let back = displayablePost.backImageURL {
                                     HStack {
                                         Spacer()
                                         PolaroidSetView(
-                                            frontImage: frontImage,
-                                            backImage: backImage,
+                                            frontImage: .url(front),
+                                            backImage: .url(back),
                                             nickname: displayablePost.nickname,
                                             createdAt: DataUtils.relativeTimeString(from: displayablePost.createdAt),
                                             caption: displayablePost.caption,
@@ -138,9 +138,6 @@ struct FeedView: View {
                         }
                         .frame(height: 520)
                         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                        .transaction { transaction in
-                            transaction.animation = .easeInOut(duration: 0.8)
-                        }
                         .animation(.easeInOut(duration: 0.3), value: viewModel.currentPostIndex)
                         .onChange(of: viewModel.currentPostIndex) { oldValue, newIndex in
                             withAnimation(.easeInOut(duration: 0.3)) {
@@ -235,7 +232,7 @@ struct FeedView: View {
                                     showToastView = true
                                 }
                             }
-                        }label: {
+                        } label: {
                             if !viewModel.displayablePosts.isEmpty{
                                 VStack(spacing: 2){
                                     Image(viewModel.displayablePosts[viewModel.currentPostIndex].isMyPost ?  "AddStickerButtonDisabled" : "AddStickerButtonAbled")
@@ -275,7 +272,8 @@ struct FeedView: View {
                         ))
                 }
             }
-        }.onAppear() {
+        }
+        .onAppear() {
             if !viewModel.isUploading && !viewModel.isLoading {
                 viewModel.loadTodayPosts()
             }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -296,7 +296,6 @@ struct FeedView: View {
         }
         .onAppear() {
             if !viewModel.isUploading && !viewModel.isLoading {
-                print("피드뷰모델 이닛 - loadtodayposts")
                 viewModel.loadTodayPosts()
             }
         }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -138,6 +138,9 @@ struct FeedView: View {
                         }
                         .frame(height: 520)
                         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                        .transaction { transaction in
+                            transaction.animation = .easeInOut(duration: 0.8)
+                        }
                         .animation(.easeInOut(duration: 0.3), value: viewModel.currentPostIndex)
                         .onChange(of: viewModel.currentPostIndex) { oldValue, newIndex in
                             withAnimation(.easeInOut(duration: 0.3)) {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -9,6 +9,7 @@ import FirebaseAuth
 import PhotosUI
 import SwiftUI
 import UIKit
+import Kingfisher
 
 struct FeedView: View {
     @EnvironmentObject var coordinator: AppCoordinator
@@ -30,7 +31,25 @@ struct FeedView: View {
             VStack(spacing: 0){
                 //네비게이션 바
                 HStack{
+                    // 캐시 삭제 버튼 (좌측)
+//                    Button {
+//                        KingfisherManager.shared.downloader.cancelAll()
+//                        ImageCache.default.clearMemoryCache()
+//                        ImageCache.default.clearDiskCache()
+//                    } label: {
+//                        HStack(spacing: 6) {
+//                            Image(systemName: "trash")
+//                                .frame(width: 20, height: 20)
+//                            Text("캐시삭제")
+//                                .font(.captionRegular14)
+//                        }
+//                        .foregroundStyle(Color.ddPrimaryBlue)
+//                        .padding(.vertical, 8)
+//                        .padding(.leading, 20)
+//                    }
+
                     Spacer()
+
                     if connectState.isConnected == false {
                         Button{
                             coordinator.push(.setting)
@@ -138,9 +157,9 @@ struct FeedView: View {
                         }
                         .frame(height: 520)
                         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                        .transaction { transaction in
-                            transaction.animation = .easeInOut(duration: 0.8)
-                        }
+//                        .transaction { transaction in
+//                            transaction.animation = .easeInOut(duration: 0.8)
+//                        }
                         .animation(.easeInOut(duration: 0.3), value: viewModel.currentPostIndex)
                         .onChange(of: viewModel.currentPostIndex) { oldValue, newIndex in
                             withAnimation(.easeInOut(duration: 0.3)) {
@@ -268,7 +287,6 @@ struct FeedView: View {
                     Spacer()
                     ToastView(toastText: "스티커는 상대방 게시물에만 붙일 수 있어요!")
                         .padding(.bottom, 114)
-                    
                         .transition(.asymmetric(
                             insertion: .move(edge: .bottom).animation(.spring()),
                             removal: .opacity.animation(.easeOut(duration: 0.7))
@@ -278,6 +296,7 @@ struct FeedView: View {
         }
         .onAppear() {
             if !viewModel.isUploading && !viewModel.isLoading {
+                print("피드뷰모델 이닛 - loadtodayposts")
                 viewModel.loadTodayPosts()
             }
         }
@@ -368,6 +387,5 @@ struct FeedView: View {
                 .ignoresSafeArea()
             }
         }
-        
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/SubViews/StickerSheetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/SubViews/StickerSheetView.swift
@@ -155,6 +155,7 @@ struct StickerContainerView: View {
     let emotion: String
     let isSelected: Bool
     let isOtherSelected: Bool
+    
     private var emotionStrokeColor: Color {
             guard let stickerEmotion = StickerEmotion(rawValue: emotion) else {
                 return .ddBlack


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #194 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- Kingfisher 도입, FeedView 경로에 캐싱 1차 적용 완료: 게시물 사진, 스티커 원본 사진 캐싱
- PhotoSaveService: url을 이미지로 변환하는 함수 downloadImage() 주석처리
- PolaroidSetView: DisplayableImage 계층 추가
- PostData: PostData URL 변환 Extension 추가
- FeedView, FeedViewModel: URL 기반 이미지 렌더링 체계 정리
(FeedViewModel에서 posref.getDocument 뒤에 (source: .defualt)를 붙인 이유: .default는 온라인이면 서버 우선, 오프라인·장애 시 캐시 폴백을 허용한다는 뜻)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/4e06f0e7-6d9a-471b-b807-17f843cebada

게시물 생성시 이동하는 애니메이션 복구함

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 게시물 업로드, 조회, 스티커 생성 수정 삭제 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다