### PR TITLE
fix: #184 FCM 토큰 관리 기능 추가 

### DIFF
--- a/DonDog-iOS/DonDog-iOS/App/AppDelegate.swift
+++ b/DonDog-iOS/DonDog-iOS/App/AppDelegate.swift
@@ -31,38 +31,35 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         AppCheck.setAppCheckProviderFactory(providerFactory)
         
         FirebaseApp.configure()
+        
         // 알림 권한 요청
         UNUserNotificationCenter.current().delegate = self
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, err in
-            print("권한 요청: \(granted), 에러: \(String(describing: err))")
-        }
-        
-        // 원격 알림 등록
-        DispatchQueue.main.async {
-            UIApplication.shared.registerForRemoteNotifications()
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
+            NSLog("권한 요청: \(granted)")
+            UNUserNotificationCenter.current().getNotificationSettings { s in
+                if s.authorizationStatus == .authorized || s.authorizationStatus == .provisional {
+                    DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
+                }
+            }
         }
         
         // FCM 토큰/메시징 델리게이트
         Messaging.messaging().delegate = self
-        
-        // 로그인 상태 변화에도 토큰 업로드
-            Auth.auth().addStateDidChangeListener { _, user in
-                guard user != nil else { return }
-                Messaging.messaging().token { token, _ in
-                    if let token = token {
-                        self.uploadTokenToServer(token)
-                    }
-                }
-            }
-        
-        // 앱이 종료된 상태에서 푸시를 탭하여 실행한 경우 딥링크를 저장
-        if let userInfo = launchOptions?[.remoteNotification] as? [AnyHashable: Any] {
-                if let link = userInfo["link"] as? String {
-                    print("앱 실행 시 딥링크 처리: \(userInfo)")
-                    self.initialDeepLink = link
-                }
+        ensureFCMTokenAndSubscribe()
+    
+        if let storedToken = NotificationService.shared.getTokenFromUserDefaults() {
+            NSLog("UserDefaults에 FCM 토큰 저장: \(storedToken)")
+        } else {
+            NSLog("UserDefaults에 FCM 토큰 없음")
         }
-        
+
+        // 앱이 종료된 상태에서 푸시 알림 실행 시 딥링크를 저장
+        if let userInfo = launchOptions?[.remoteNotification] as? [AnyHashable: Any] {
+            if let link = userInfo["link"] as? String {
+                print("앱 실행 시 딥링크 처리: \(userInfo)")
+                self.initialDeepLink = link
+            }
+        }
         return true
     }
     
@@ -82,22 +79,19 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     // APNs device token → Firebase Auth
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        // Firebase Auth (전화번호 인증용)
-        Auth.auth().setAPNSToken(deviceToken, type: .prod)
-        
         // FCM
         Messaging.messaging().apnsToken = deviceToken
-        
-        Messaging.messaging().token { token, error in
-            guard let token = token else { return }
-            print("FCM 토큰 (post-APNs): \(token)")
-            self.uploadTokenToServer(token)
-        }
+
     }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.list, .banner])
+    }
+    
     
     func application(_ application: UIApplication,
                      didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("APNs 등록 실패: \(error.localizedDescription)")
+        NSLog("APNs 등록 실패: \(error.localizedDescription)")
     }
     
     // Handle custom URL scheme for reCAPTCHA callback & deeplinks
@@ -121,47 +115,30 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     // FCM MessagingDelegate - FCM이 토큰을 갱신하면 사용, APNs 토큰이 이미 있다면 여기서 구독 시도
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let token = fcmToken else { return }
-        print("FCM 토큰 (delegate): \(token)")
-        self.uploadTokenToServer(token)
-        self.subscribeDailyTopic()
+        NSLog("FCM 토큰 (delegate): \(token)")
+        NotificationService.shared.uploadFCMToken(token)
     }
     
-    // UNUserNotificationCenterDelegate
-    func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                willPresent notification: UNNotification,
-                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.banner, .list, .sound])
-    }
-
+    // 푸시 알림을 누르면 포함된 link의 정보를 추출하여 딥링크 수행
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
-
+        
         let userInfo = response.notification.request.content.userInfo
-        print("tapped notification: \(userInfo)")
+        NSLog("tapped notification: \(userInfo)")
         if let link = userInfo["link"] as? String {
             NotificationCenter.default.post(name: .openDeepLink, object: link)
         }
-        completionHandler()
     }
     
-    private func subscribeDailyTopic() {
-        Messaging.messaging().subscribe(toTopic: "daily_random_notification") { error in
-            if let error = error {
-                print("토픽 구독 에러: \(error.localizedDescription)")
-            } else {
-                print("daily_random_notification 구독 성공")
-            }
-        }
-    }
-    
-    private func uploadTokenToServer(_ token: String) {
-            guard let uid = Auth.auth().currentUser?.uid else {
-                print("⚠️ 현재 로그인한 사용자 없음 — 로그인 이후 다시 업로드 필요")
-                return
-            }
-            NotificationService.shared.uploadFCMToken(token)
-            print("Firestore에 FCM 토큰 업로드 완료: \(token)")
-        }
+    private func ensureFCMTokenAndSubscribe() {
+        Messaging.messaging().token { token, error in
+            if let token {
+                NotificationService.shared.uploadFCMToken(token)
 
+            } else if let error {
+                NSLog("초기 토큰 획득 실패: \(error.localizedDescription)")
+            }
+        }
+    }
 }

--- a/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FirebaseAuth
 import FirebaseFirestore
+import FirebaseMessaging
 
 extension Notification.Name {
     static let authServiceReconfigureRouting = Notification.Name("AuthService.ReconfigureRouting")
@@ -51,7 +52,7 @@ final class AuthService {
                 if coordinator.root == route { return }
                 coordinator.replaceRoot(route)
                 
-                print("[AuthService replaceRootinAuthService함수] 🔄 \(coordinator.root) → \(route)")
+                NSLog("[AuthService replaceRootinAuthService함수] 🔄 \(coordinator.root) → \(route)")
             }
         }
         
@@ -62,7 +63,7 @@ final class AuthService {
             replaceRootinAuthService(.welcome, coordinator: coordinator)
             self.userDocListenr?.remove()
             self.userDocListenr = nil
-            print("[AuthService] currentUser 없음 → welcome 화면으로 이동")
+            NSLog("[AuthService] currentUser 없음 → welcome 화면으로 이동")
             return
         }
         
@@ -77,13 +78,32 @@ final class AuthService {
                     ConnectStateService.shared.reset()
                 }
                 replaceRootinAuthService(.welcome, coordinator: coordinator)
-                print("[AuthService] IDToken 분실로 current User 찾을 수 없음 → welcome 화면으로 이동")
+                NSLog("[AuthService] IDToken 분실로 current User 찾을 수 없음 → welcome 화면으로 이동")
                 return
             }
             
             Task { @MainActor in
                 ConnectStateService.shared.reset()
             }
+            
+            // 현재 기기의 FCM 토큰 firestore에 업로드
+            Messaging.messaging().token { token, error in
+                if let token = token {
+                    NotificationService.shared.uploadFCMToken(token)
+
+                    // 로그인 및 토큰 업로드 성공 후 토픽 구독
+                    Messaging.messaging().subscribe(toTopic: "daily_random_notification") { error in
+                        if let error = error {
+                            NSLog("토픽 구독 실패: \(error.localizedDescription)")
+                        } else {
+                            NSLog("토픽 구독 성공")
+                        }
+                    }
+                } else if let error = error {
+                    NSLog("FCM 토큰 획득 실패 (AuthService): \(error.localizedDescription)")
+                }
+            }
+            
             let uid = refresehUser.uid
             let userDoc = Firestore.firestore().collection("Users").document(uid)
             
@@ -98,7 +118,7 @@ final class AuthService {
                 /// 에러 또는 스냅샷 nil 통합 처리
                 guard error == nil, let userDoc = userDoc else {
                     if let nsError = error as NSError? {
-                        print("⚠️ 사용자 문서 조회 오류: \(nsError.localizedDescription) → welcome로 이동")
+                        NSLog("⚠️ 사용자 문서 조회 오류: \(nsError.localizedDescription) → welcome로 이동")
                         Task { @MainActor in
                             ConnectStateService.shared.reset()
                         }
@@ -134,10 +154,10 @@ final class AuthService {
                     ConnectStateService.shared.roomId = roomId
                     ConnectStateService.shared.isConnected = (roomId?.isEmpty == false)
                     if let rid = roomId, !rid.isEmpty {
-                        print("[AuthService] 🔗 연결됨 roomId=\(rid)")
+                        NSLog("[AuthService] 🔗 연결됨 roomId=\(rid)")
                         replaceRootinAuthService(.feed, coordinator: coordinator)
                     } else {
-                        print("[AuthService] 🔓 미연결 상태 (roomId 없음)")
+                        NSLog("[AuthService] 🔓 미연결 상태 (roomId 없음)")
                     }
                 }
                 

--- a/DonDog-iOS/DonDog-iOS/Core/Services/NotificationService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/NotificationService.swift
@@ -12,50 +12,62 @@ import FirebaseMessaging
 final class NotificationService {
     static let shared = NotificationService()
     private init() {}
-
-    // 로그인 이후 또는 토큰 갱신 시 호출
+    
+    private let fcmTokenKey = "fcmToken"
+    
+    private func saveTokenToUserDefaults(_ token: String) {
+        UserDefaults.standard.set(token, forKey: fcmTokenKey)
+    }
+    
+    func getTokenFromUserDefaults() -> String? {
+        return UserDefaults.standard.string(forKey: fcmTokenKey)
+    }
+    
+    // 현재 로그인 된 사용자 uid 기반으로 firestore에 저장
     func uploadFCMToken(_ token: String) {
         guard let uid = Auth.auth().currentUser?.uid else { return }
-        Firestore.firestore()
+        let ref = Firestore.firestore()
+            .collection("Users").document(uid)
+            .collection("fcmTokens").document(token)
+        
+        let env: String
+#if DEBUG
+        env = "dev"
+#else
+        env = "prod"
+#endif
+        
+        let info: [String: Any] = [
+            "env": env,
+            "updatedAt": FieldValue.serverTimestamp()
+        ]
+        
+        ref.setData(info, merge: true) { err in
+            if let err = err {
+                print("FCM 토큰 업로드 실패: \(err)")
+            } else {
+                print("FCM 토큰 업로드 성공: \(token) [\(env)]")
+                self.saveTokenToUserDefaults(token) // 로컬 캐싱
+            }
+        }
+    }
+    
+    // 현재 사용자 로그아웃 또는 회원 탈퇴 시 토큰 삭제
+    func deleteFCMToken() async throws {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            return
+        }
+        
+        let token = try await Messaging.messaging().token()
+        
+        try await Firestore.firestore()
             .collection("Users")
             .document(uid)
             .collection("fcmTokens")
             .document(token)
-            .setData(["updatedAt": FieldValue.serverTimestamp()], merge: true)
-    }
-    
-    // 현재 사용자 로그아웃 또는 회원 탈퇴 시 토큰 삭제
-    func deleteFCMToken(completion: ((Error?) -> Void)? = nil) {
-        guard let uid = Auth.auth().currentUser?.uid else {
-            completion?(nil)
-            return
-        }
+            .delete()
         
-        Messaging.messaging().token { token, error in
-            if let error = error {
-                print("FCM 토큰 가져오기 실패: \(error)")
-                completion?(error)
-                return
-            }
-            
-            guard let token = token else {
-                completion?(nil)
-                return
-            }
-            
-            Firestore.firestore()
-                .collection("Users")
-                .document(uid)
-                .collection("fcmTokens")
-                .document(token)
-                .delete { error in
-                    if let error = error {
-                        print("Firestore 토큰 삭제 실패: \(error)")
-                    } else {
-                        print("Firestore에서 FCM 토큰 삭제 완료")
-                    }
-                    completion?(error)
-                }
-        }
+        UserDefaults.standard.removeObject(forKey: self.fcmTokenKey)
+        print("Firestore에서 FCM 토큰 삭제 완료")
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViewModels/SettingViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViewModels/SettingViewModel.swift
@@ -8,15 +8,16 @@
 import Combine
 import FirebaseAuth
 import FirebaseFirestore
+import FirebaseMessaging
 
 final class SettingViewModel: ObservableObject {
     @Published var showLogoutConfirm = false
     @Published var showDeleteConfirm = false
     func logout() async {
-        NotificationService.shared.deleteFCMToken() { error in
-            if let error = error {
-                print("FCM 토큰 삭제 실패(로그아웃 계속 진행): \(error.localizedDescription)")
-            }
+        do {
+            try await NotificationService.shared.deleteFCMToken()
+        } catch {
+            NSLog("FCM 토큰 삭제 실패(로그아웃 계속 진행): \(error.localizedDescription)")
         }
         
         do {
@@ -24,10 +25,11 @@ final class SettingViewModel: ObservableObject {
             // 메인에서 세션 리셋 + 캐시 제거
             await MainActor.run {
                 URLCache.shared.removeAllCachedResponses()
+                
             }
-            print("로그아웃 성공")
+            NSLog("로그아웃 성공")
         } catch {
-            print("로그아웃 실패: \(error.localizedDescription)")
+            NSLog("로그아웃 실패: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #184 

---

### 🧶 주요 변경 내용 (Summary)
#### production (TestFlight) 환경에서 알림이 수신되지 않는 문제
- db 내의 fcmTokens에 FCM Token이 로그인 할 때 마다 누적되어 토큰 관리가 어려웠음
- 디버깅을 위해 빌드 환경 (dev/prod)을 구분하여 토큰 정보를 저장하고 추적
- 성공적으로 업로드된 토큰은 UserDefaults에 캐싱하여 불필요한 중복 업로드를 방지
- 로그인 시 db에 업로드, 랜덤 알림 토픽 구독 / 로그아웃 시 db에서 삭제하고 알림 수신을 중단하도록 명확한 푸시 알림 로직 확보

#### 트러블 슈팅
- 알림이 수신되지 않는 문제를 찾기 위해 로직을 개선했으나 명확한 원인은 APNs key의 APNs Environment이 Sandbox only이기 때문이었습니다.
- 토큰 관리 로직 수정으로 중복 토큰을 제거 + Sandbox & Production 환경의 Key로 재발급 후 배포한 버전 15에서는 푸시 알림이 정상적으로 작동됩니다.

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작

