### PR TITLE
refact: #196 아카이브뷰의 썸네일 캐싱

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -115,7 +115,6 @@
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
-		8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -123,6 +122,7 @@
 		8B6E11892E968E2B0082B24C /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		8B6E118C2E976F380082B24C /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
 		8B6E11902E9771EA0082B24C /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		8B6F16AC2EAF00F90046120A /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B7377DF2E9546030001EFCD /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		8B7729062EA73A3000344491 /* InWebSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InWebSheetView.swift; sourceTree = "<group>"; };
 		8BA62EA32E9149A00054EB8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -647,7 +647,7 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */;
+			productReference = 8B6F16AC2EAF00F90046120A /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchivePostContainer.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchivePostContainer.swift
@@ -6,51 +6,64 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 struct ArchivePostContainer: View {
     let url: URL
     let day: Int
     
+    @State private var isLoading = false
+    @State private var isFailed = false
+    
     var body: some View {
         ZStack(alignment: .center) {
-            AsyncImage(url: url) { state in
-                switch state {
-                case .success(let image):
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 75, height: 100)
-                        .clipped()
-                        .transition(.opacity)
+            KFImage.url(url)
+                .onProgress { receivedSize,totalSize in
+                    isLoading = true
+                    isFailed = false
+                }
+                .onSuccess { _ in
+                    isLoading = false
+                    isFailed = false
+                }
+                .onFailure { _ in
+                    isLoading = false
+                    isFailed = true
+                }
+                .placeholder {
+                    Rectangle()
+                        .fill(.ddWhite)
                         .cornerRadius(8)
-                        .overlay(
+                        .frame(width: 75, height: 100)
+                }
+                .resizable()
+                .scaledToFill()
+                .frame(width: 75, height: 100)
+                .clipped()
+                .transition(.opacity)
+                .cornerRadius(8)
+                .overlay(
+                    Group {
+                        if isFailed {
+                            ZStack {
+                                Rectangle()
+                                    .fill(.ddGray600)
+                                    .cornerRadius(8)
+                                    .overlay(Image(systemName: "exclamationmark.triangle").foregroundStyle(.white))
+                                    .frame(width: 75, height: 100)
+                            }
+                        } else {
                             ZStack {
                                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                    .fill(.ddGray1000.opacity(0.3))
+                                    .fill(.ddBlack30)
                                 
                                 Text("\(day)일")
                                     .font(.subtitleSemiBold16)
                                     .foregroundStyle(.ddWhite)
                             }
-                        )
-                    
-                case .failure:
-                    Rectangle()
-                        .fill(.ddGray600)
-                        .cornerRadius(8)
-                        .overlay(Image(systemName: "photo").opacity(0.7))
-                        .frame(width: 75, height: 100)
-                    
-                case .empty:
-                    Rectangle()
-                        .fill(.ddGray600.opacity(0.2))
-                        .cornerRadius(8)
-                        .frame(width: 75, height: 100)
-                    
-                @unknown default:
-                    Color.clear.frame(width: 75, height: 100)
-                }
-            }
+                        }
+                    }
+                )
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchivePostContainer.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchivePostContainer.swift
@@ -12,22 +12,18 @@ struct ArchivePostContainer: View {
     let url: URL
     let day: Int
     
-    @State private var isLoading = false
     @State private var isFailed = false
     
     var body: some View {
         ZStack(alignment: .center) {
             KFImage.url(url)
                 .onProgress { receivedSize,totalSize in
-                    isLoading = true
                     isFailed = false
                 }
                 .onSuccess { _ in
-                    isLoading = false
                     isFailed = false
                 }
                 .onFailure { _ in
-                    isLoading = false
                     isFailed = true
                 }
                 .placeholder {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #196 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 아카이브뷰의 썸네일을 캐싱했습니다. 다른 뷰에 나갔다 와도 로딩이 뜨지 않습니다

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/6be390e6-6958-4c19-a4f5-f44ec014f6bb


