### PR TITLE
refact: #121 ConnectStateService를 통한 사용자 정보 관리 중앙화

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
@@ -73,7 +73,7 @@ final class AuthService {
         
         user.getIDTokenResult(forcingRefresh: true) { _, _ in
             /// 로그인 안됨 -> welcome으로 이동
-            guard let refresehUser = Auth.auth().currentUser else {
+            guard let refreshUser = Auth.auth().currentUser else {
                 Task { @MainActor in
                     ConnectStateService.shared.reset()
                 }
@@ -90,7 +90,7 @@ final class AuthService {
             Messaging.messaging().token { token, error in
                 if let token = token {
                     NotificationService.shared.uploadFCMToken(token)
-
+                    
                     // 로그인 및 토큰 업로드 성공 후 토픽 구독
                     Messaging.messaging().subscribe(toTopic: "daily_random_notification") { error in
                         if let error = error {
@@ -104,7 +104,7 @@ final class AuthService {
                 }
             }
             
-            let uid = refresehUser.uid
+            let uid = refreshUser.uid
             let userDoc = Firestore.firestore().collection("Users").document(uid)
             
             self.userDocListenr?.remove()
@@ -146,22 +146,56 @@ final class AuthService {
                 if userDoc.metadata.hasPendingWrites {
                     return
                 }
-
+                
                 /// user 문서가 있을 때 -> feed로 이동
                 let data = userDoc.data() ?? [:]
                 let roomId = data["roomId"] as? String
-                Task { @MainActor in
-                    ConnectStateService.shared.roomId = roomId
-                    ConnectStateService.shared.isConnected = (roomId?.isEmpty == false)
-                    if let rid = roomId, !rid.isEmpty {
-                        NSLog("[AuthService] 🔗 연결됨 roomId=\(rid)")
-                        replaceRootinAuthService(.feed, coordinator: coordinator)
-                    } else {
+                
+                Task {
+                    let state = ConnectStateService.shared
+                    state.myUid = refreshUser.uid
+                    state.myName = data["name"] as? String
+                    
+                    guard let rid = roomId, !rid.isEmpty else {
+                        state.reset()
                         NSLog("[AuthService] 🔓 미연결 상태 (roomId 없음)")
+                        replaceRootinAuthService(.feed, coordinator: coordinator)
+                        return
+                    }
+                    
+                    do {
+                        let db = Firestore.firestore()
+                        let roomDoc = try await db.collection("Rooms").document(rid).getDocument()
+                        
+                        guard let roomData = roomDoc.data(), let participants = roomData["participants"] as? [String] else {
+                            state.reset()
+                            replaceRootinAuthService(.welcome, coordinator: coordinator)
+                            return
+                        }
+                        
+                        if let partnerUid = participants.first(where: { $0 != refreshUser.uid }) {
+                            let partnerDoc = try await db.collection("Users").document(partnerUid).getDocument()
+                            state.partnerUid = partnerUid
+                            state.partnerName = partnerDoc.data()?["name"] as? String
+                            NSLog("[AuthService] Partner Info: uid = \(partnerUid), name = \(state.partnerName ?? "nil")")
+                        } else {
+                            state.partnerUid = nil
+                            state.partnerName = nil
+                        }
+                        
+                        state.roomId = rid
+                        state.isConnected = true
+                        
+                        NSLog("[AuthService] My Info: uid = \(state.myUid ?? "nil"), name = \(state.myName ?? "nil")")
+                        NSLog("[AuthService] 상태: 연결 상태 =\(state.isConnected), roomId=\(state.roomId ?? "nil")")
+                        replaceRootinAuthService(.feed, coordinator: coordinator)
+                        
+                    } catch {
+                        NSLog("AuthService에서 정보 로딩 중 에러: \(error.localizedDescription)")
+                        state.reset()
+                        replaceRootinAuthService(.welcome, coordinator: coordinator)
                     }
                 }
-                
-                
             }
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Core/Services/ConnectStateService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/ConnectStateService.swift
@@ -5,8 +5,8 @@
 //  Created by 이주현 on 10/19/25.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 final class ConnectStateService: ObservableObject {
@@ -15,9 +15,17 @@ final class ConnectStateService: ObservableObject {
     
     @Published var isConnected: Bool = false
     @Published var roomId: String? = nil
+    @Published var myUid: String? = nil
+    @Published var myName: String? = nil
+    @Published var partnerUid: String? = nil
+    @Published var partnerName: String? = nil
     
     func reset() {
         self.isConnected = false
         self.roomId = nil
+        self.myUid = nil
+        self.myName = nil
+        self.partnerUid = nil
+        self.partnerName = nil
     }
 }


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #121 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 각 ViewModel에서 개별적으로 닉네임 같은 공통 정보를 조회하고 있었습니다. 이로 인해 불필요한 중복 호출이 발생하고 데이터 상태 관리가 분산되어 있었습니다.
- ConnectStateService 싱글톤이 로그인 시점에 한 번만 정보를 가져와 저장하도록 변경했습니다. 앱 전역에서 ConnectStateService를 통해 일관되게 사용하도록 했습니다.

#### ✅ 적용 방법
각자 맡은 부분에 아래 내용을 참고해서 적용해주시면 됩니다.

**1. ViewModel**
- ViewModel 내부에 있던 myNickname, partnerNickname 같은 변수들을 제거합니다.
- 해당 정보를 가져오던 fetchPartnerNickname(), getUserName() 등의 함수를 모두 제거합니다.

**2. View**
- 기존에 viewModel.myNickname처럼 ViewModel을 통해 접근하던 코드를 connectState.myName과 같이 connectState에서 직접 데이터를 사용하도록 수정합니다. (정보가 없을 수 있으므로 nil 처리 필요)
---

### 📸 스크린샷 (Optional)
<img width="480" height="248" alt="스크린샷 2025-10-27 11 54 16" src="https://github.com/user-attachments/assets/666d448f-6a73-4ccf-b191-a000e95b2417" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작
- [x] 로그인시 정보 조회 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- AuthService가 역할이 너무 많아서 추후에 notification과 userInfo 관련된 부분들은 모두 분리해야할 필요성이 있어보입니다!