### PR TITLE
fix: #211 탈퇴 오류 해결

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -115,7 +115,6 @@
 		61C9B1A32E9BFC830007C8F4 /* ArchiveDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDay.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveMonth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMonth.swift; sourceTree = "<group>"; };
 		8B354C7F2EA4A17A0030F9A1 /* ConnectStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectStateService.swift; sourceTree = "<group>"; };
-		8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -123,6 +122,7 @@
 		8B6E11892E968E2B0082B24C /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		8B6E118C2E976F380082B24C /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
 		8B6E11902E9771EA0082B24C /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		8B6F16B02EAF170F0046120A /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B7377DF2E9546030001EFCD /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		8B7729062EA73A3000344491 /* InWebSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InWebSheetView.swift; sourceTree = "<group>"; };
 		8BA62EA32E9149A00054EB8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -369,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
+				8B6F16B02EAF170F0046120A /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -647,7 +648,7 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8B3A590C2EAD132900A6C09D /* DonDog-iOS.app */;
+			productReference = 8B6F16B02EAF170F0046120A /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
@@ -90,8 +90,8 @@ final class AuthNumberViewModel: ObservableObject {
             let success = await deleteUserDataAndAuth()
             
             await MainActor.run {
-                AuthService.isAccountDeletionInProgress = false
                 if success {
+                    AuthService.isAccountDeletionInProgress = false
                     self.coordinator?.replaceRoot(.welcome)
                 }
                 NotificationCenter.default.post(name: .authServiceReconfigureRouting, object: nil)
@@ -114,7 +114,7 @@ final class AuthNumberViewModel: ObservableObject {
 
         do {
             // 1) Firestore 정리
-            // Users/{uid}를 읽어 roomId 등을 확인
+            // Users/{uid}를 읽어 roomId 확인
             let userDoc = db.collection("Users").document(uid)
             let userData = try await userDoc.getDocument()
             var roomId: String? = nil
@@ -122,13 +122,7 @@ final class AuthNumberViewModel: ObservableObject {
                 roomId = rid
             }
 
-            let deleteTgt = db.batch()
-
             // Rooms
-            // 1-1) participants에서 내가 마지막 유저인지 확인
-            // 1-1-1) 내가 마지막 유저라면 - rooms 모두 삭제, storage 삭제
-            // 1-1-2) 내가 마지막 유저가 아니라면 - participants에서만 나 삭제
-            // (Users/{uid}.roomId 필드 기반 우선 처리 + 방어적으로 participants 검색)
             var roomDocToCheck: [DocumentReference] = []
             if let rid = roomId, !rid.isEmpty {
                 roomDocToCheck.append(db.collection("Rooms").document(rid))
@@ -144,33 +138,31 @@ final class AuthNumberViewModel: ObservableObject {
                 uniqueRids[ref.path] = ref
             }
 
-            try await deleteTgt.commit()
-
-            // participants에서 uid 제거 (존재하는 방에 한해 개별 업데이트)
+            // 1-1) participants에서 내가 마지막 유저인지 확인
+            // 1-1-1) 내가 마지막 유저라면 - rooms 모두 삭제, storage 삭제
+            // 1-1-2) 내가 마지막 유저가 아니라면 - participants에서만 나 삭제
+            
+            // 각 Room 처리: 마지막 참가자면 Storage → posts → comments → Room 삭제, 아니면 participants에서 내 uid만 제거
             for (_, ref) in uniqueRids {
-                do {
-                    try await ref.updateData(["participants": FieldValue.arrayRemove([uid])])
-                } catch {
-                    let ns = error as NSError
-                    if ns.domain == FirestoreErrorDomain,
-                       FirestoreErrorCode.Code(rawValue: ns.code) == .notFound {
-                        // 방이 이미 삭제된 경우: 무시하고 계속 진행
-                        continue
-                    } else {
-                        throw error
-                    }
-                }
-            }
-
-            // participants 제거 후 빈 방이면 삭제 방 삭제, 방 내부의 storage 파일 삭제
-            for (_, ref) in uniqueRids {
+                // 최신 스냅샷 확인
                 let snap = try await ref.getDocument()
-                if let data = snap.data(), let parts = data["participants"] as? [String], parts.isEmpty {
-                    let storage = Storage.storage()
-                    let postsDoc = try await ref.collection("posts").getDocuments()
+                guard let data = snap.data(), let parts = data["participants"] as? [String], parts.contains(uid) else { continue }
 
+                if parts.count > 1 {
+                    // 2명이상 → participants에서 내 uid만 제거
+                    try await ref.updateData(["participants": FieldValue.arrayRemove([uid])])
+                    do {
+                        let verifySnap = try await ref.getDocument(source: .server)
+                        _ = (verifySnap.data()?["participants"] as? [String]) ?? []
+                    } catch {
+                        _ = error as NSError
+                    }
+                } else {
+                    // 마지막 1명(본인) → 모든 Rooms 데이터, storage 삭제
+                    // 1) posts storage 삭제
+                    let postsSnap = try await ref.collection("posts").getDocuments()
                     func isFirebaseStorageURL(_ s: String) -> Bool {
-                        return s.hasPrefix("https://firebasestorage.googleapis.com")
+                        s.hasPrefix("https://firebasestorage.googleapis.com") || s.hasPrefix("gs://")
                     }
                     func collectStorageURLs(from any: Any, into result: inout [String]) {
                         switch any {
@@ -184,49 +176,64 @@ final class AuthNumberViewModel: ObservableObject {
                             break
                         }
                     }
-
-                    // 2) 모든 Storage URL 동적 수집 후 삭제
                     var urlsToDelete: [String] = []
-                    for doc in postsDoc.documents {
-                        let data = doc.data()
-                        collectStorageURLs(from: data, into: &urlsToDelete)
-                    }
-                    // 중복 제거
+                    for doc in postsSnap.documents { collectStorageURLs(from: doc.data(), into: &urlsToDelete) }
                     urlsToDelete = Array(Set(urlsToDelete))
-
+                    let storage = Storage.storage()
                     try await withThrowingTaskGroup(of: Void.self) { group in
                         for url in urlsToDelete {
-                            group.addTask {
-                                try await storage.reference(forURL: url).delete()
-                            }
+                            group.addTask { try await storage.reference(forURL: url).delete() }
                         }
                         try await group.waitForAll()
                     }
 
-                    // 3) posts 문서 삭제 (배치)
-                    if !postsDoc.isEmpty {
-                        let deleteTgt = db.batch()
-                        postsDoc.documents.forEach { deleteTgt.deleteDocument($0.reference) }
-                        try await deleteTgt.commit()
+                    // 2) posts 삭제
+                    if !postsSnap.isEmpty {
+                        let batch = db.batch()
+                        postsSnap.documents.forEach { batch.deleteDocument($0.reference) }
+                        try await batch.commit()
                     }
 
-                    // 4) 마지막으로 Rooms/{roomId} 문서 삭제
+                    // 3) comments 삭제
+                    let postIds = postsSnap.documents.map { $0.documentID }
+                    for postId in postIds {
+                        let holderRef = ref.collection("comments").document(postId) // Rooms/{roomId}/comments/{postId}
+                        let subCommentsRef = holderRef.collection("comments")       // Rooms/{roomId}/comments/{postId}/comments
+
+                        if let subCommentsSnap = try? await subCommentsRef.getDocuments(), !subCommentsSnap.isEmpty {
+                            let batch = db.batch()
+                            subCommentsSnap.documents.forEach { batch.deleteDocument($0.reference) }
+                            try? await batch.commit()
+                        }
+                        try? await holderRef.delete()
+                    }
+                    // 4) Room 문서 삭제
                     try await ref.delete()
                 }
             }
-            
             
             // 1-2) Invites 에서 uid가 있는 문서 삭제
             let invitesDoc = db.collection("Invites")
             let inviterQuery = invitesDoc.whereField("inviterUid", isEqualTo: uid)
             let inviterData = try await inviterQuery.getDocuments()
-            for doc in inviterData.documents {
-                deleteTgt.deleteDocument(doc.reference)
+            if !inviterData.isEmpty {
+                let batch = db.batch()
+                inviterData.documents.forEach { batch.deleteDocument($0.reference) }
+                try await batch.commit()
             }
             
-            // 1-3) Users/{uid} 삭제
-            deleteTgt.deleteDocument(userDoc)
-            
+            // 1-3) Users/{uid} 삭제 (하위 fcmTokens 먼저 삭제)
+            do {
+                let tokensSnap = try await userDoc.collection("fcmTokens").getDocuments()
+                if !tokensSnap.isEmpty {
+                    let batch = db.batch()
+                    tokensSnap.documents.forEach { batch.deleteDocument($0.reference) }
+                    try await batch.commit()
+                }
+            }
+            // Users/{uid} 문서 삭제
+            try await userDoc.delete()
+
             // 2) Firebase Auth 사용자 삭제
             do {
                 try await user.delete()

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
@@ -30,7 +30,7 @@ final class AuthNumberViewModel: ObservableObject {
     @Published var codeError: String? = nil
     
     @Published var isNumberWithdraw = false
-    @Published var showAlert = false
+    @Published var showWithdrawErrorAlert = false
     @Published var alertMessage: String? = nil
     
     init(isNumberWithdraw: Bool = false) {
@@ -124,25 +124,16 @@ final class AuthNumberViewModel: ObservableObject {
 
             let deleteTgt = db.batch()
 
-            // Users/{uid} 삭제
-            deleteTgt.deleteDocument(userDoc)
-
-            // Invites 에서 uid가 있는 문서 삭제
-            let invitesDoc = db.collection("Invites")
-            let inviterQuery = invitesDoc.whereField("inviterUid", isEqualTo: uid)
-            let inviterData = try await inviterQuery.getDocuments()
-            for doc in inviterData.documents {
-                deleteTgt.deleteDocument(doc.reference)
-            }
-
             // Rooms
-            // participants에서 제거, 비면 방 삭제
+            // 1-1) participants에서 내가 마지막 유저인지 확인
+            // 1-1-1) 내가 마지막 유저라면 - rooms 모두 삭제, storage 삭제
+            // 1-1-2) 내가 마지막 유저가 아니라면 - participants에서만 나 삭제
             // (Users/{uid}.roomId 필드 기반 우선 처리 + 방어적으로 participants 검색)
             var roomDocToCheck: [DocumentReference] = []
             if let rid = roomId, !rid.isEmpty {
                 roomDocToCheck.append(db.collection("Rooms").document(rid))
             }
-            // participants 배열에 내 uid가 포함된 모든 방을 역으로 검색
+            // 재확인 - participants 배열에 내 uid가 포함된 모든 방을 역으로 검색
             let roomsDoc = db.collection("Rooms").whereField("participants", arrayContains: uid)
             let roomData = try await roomsDoc.getDocuments()
             roomDocToCheck.append(contentsOf: roomData.documents.map { $0.reference })
@@ -224,6 +215,18 @@ final class AuthNumberViewModel: ObservableObject {
                 }
             }
             
+            
+            // 1-2) Invites 에서 uid가 있는 문서 삭제
+            let invitesDoc = db.collection("Invites")
+            let inviterQuery = invitesDoc.whereField("inviterUid", isEqualTo: uid)
+            let inviterData = try await inviterQuery.getDocuments()
+            for doc in inviterData.documents {
+                deleteTgt.deleteDocument(doc.reference)
+            }
+            
+            // 1-3) Users/{uid} 삭제
+            deleteTgt.deleteDocument(userDoc)
+            
             // 2) Firebase Auth 사용자 삭제
             do {
                 try await user.delete()
@@ -233,13 +236,13 @@ final class AuthNumberViewModel: ObservableObject {
                 if nsError.code == AuthErrorCode.requiresRecentLogin.rawValue {
                     print("[회원탈퇴] requiresRecentLogin: 최근 로그인 후 다시 시도 필요")
                     await MainActor.run {
-                        self.showAlert = true
+                        self.showWithdrawErrorAlert = true
                         self.alertMessage = "탈퇴 중 오류가 생겼습니다. 다시 시도해주세요."
                     }
                 } else {
                     print("[회원탈퇴] Auth 삭제 중 오류: \(nsError.localizedDescription)")
                     await MainActor.run {
-                        self.showAlert = true
+                        self.showWithdrawErrorAlert = true
                         self.alertMessage = "탈퇴 중 오류가 생겼습니다. 다시 시도해주세요."
                     }
                 }
@@ -249,7 +252,7 @@ final class AuthNumberViewModel: ObservableObject {
             let nsError = error as NSError
             print("[회원탈퇴] 오류: \(nsError.localizedDescription)")
             await MainActor.run {
-                self.showAlert = true
+                self.showWithdrawErrorAlert = true
                 self.alertMessage = "탈퇴 중 오류가 생겼습니다. 다시 시도해주세요."
             }
             return false

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
@@ -62,6 +62,7 @@ final class AuthNumberViewModel: ObservableObject {
                 if let error = error {
                     print("[Auth][signIn] error: \(error.localizedDescription)")
                     self.codeError = "인증번호를 다시 확인해주세요."
+                    self.isLoading = false
                 } else {
                     self.codeError = nil
                     print("인증 성공")
@@ -76,7 +77,32 @@ final class AuthNumberViewModel: ObservableObject {
                         self.routeAfterSignIn()
                     }
                 }
-                self.isLoading = false
+            }
+        }
+    }
+    
+    private func routeAfterSignIn() {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let docRef = Firestore.firestore().collection("Users").document(uid)
+
+        docRef.getDocument { [weak self] snapshot, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                print("[Auth][routeAfterSignIn] fetch user doc error: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.coordinator?.push(.profileSetup)
+                }
+                return
+            }
+
+            let exists = (snapshot?.exists == true)
+            DispatchQueue.main.async {
+                if exists {
+                    self.coordinator?.replaceRoot(.feed)
+                } else {
+                    self.coordinator?.replaceRoot(.profileSetup)
+                }
             }
         }
     }
@@ -86,9 +112,7 @@ final class AuthNumberViewModel: ObservableObject {
             await MainActor.run {
                 AuthService.isAccountDeletionInProgress = true
             }
-            
             let success = await deleteUserDataAndAuth()
-            
             await MainActor.run {
                 if success {
                     AuthService.isAccountDeletionInProgress = false
@@ -265,33 +289,4 @@ final class AuthNumberViewModel: ObservableObject {
             return false
         }
     }
-    
-    private func routeAfterSignIn() {
-        guard let uid = Auth.auth().currentUser?.uid else { return }
-        let docRef = Firestore.firestore().collection("Users").document(uid)
-
-        docRef.getDocument { [weak self] snapshot, error in
-            guard let self = self else { return }
-
-            if let error = error {
-                print("[Auth][routeAfterSignIn] fetch user doc error: \(error.localizedDescription)")
-                DispatchQueue.main.async {
-                    self.coordinator?.push(.profileSetup)
-                }
-                return
-            }
-
-            let exists = (snapshot?.exists == true)
-            DispatchQueue.main.async {
-                if exists {
-                    self.coordinator?.replaceRoot(.feed)
-                    self.isLoading = false
-                } else {
-                    self.coordinator?.replaceRoot(.profileSetup)
-                    self.isLoading = false
-                }
-            }
-        }
-    }
-    
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/AuthNumberView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/AuthNumberView.swift
@@ -59,7 +59,9 @@ struct AuthNumberView: View {
         .dismissKeyboard()
         .alert("", isPresented: $viewModel.showWithdrawErrorAlert) {
             Button("확인", role: .cancel) {
-                // coordinator.push(.setting)
+                AuthService.isAccountDeletionInProgress = false
+                coordinator.pop()
+                coordinator.pop()
             }
         } message: {
             Text(viewModel.alertMessage ?? "")

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/AuthNumberView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/AuthNumberView.swift
@@ -57,9 +57,9 @@ struct AuthNumberView: View {
         .padding(.horizontal, 20)
         .backHiddenSwipeEnabled()
         .dismissKeyboard()
-        .alert("", isPresented: $viewModel.showAlert) {
+        .alert("", isPresented: $viewModel.showWithdrawErrorAlert) {
             Button("확인", role: .cancel) {
-                // setting view로 돌아가게
+                // coordinator.push(.setting)
             }
         } message: {
             Text(viewModel.alertMessage ?? "")


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #211 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 회원탈퇴 로직 안정화 및 삭제 순서 수정
  - Firestore 보안 규칙으로 인해, 사용자가 Users 문서를 먼저 삭제하거나 participants에서 본인을 먼저 제거할 경우 posts 및 comments 삭제 권한이 상실되는 문제가 존재했음
  - 삭제 순서를 Storage → posts → comments → Room → Users 순으로 재구성하여 보안 규칙과 충돌하지 않도록 수정함
  - 또 Users에 fcmTokens 하위 컬렉션이 추가되면서, 상위 문서만 삭제되고 빈 컬렉션이 남는 문제가 발생해서 fcmTokens부터 일괄 삭제한 뒤 Users 문서를 삭제하도록 변경함
- 탈퇴 시 오류가 생겨 팝업 알람이 뜨면, 사용자가 “확인”을 누르면 뒤로가기 2회(pop 2)으로 정상적으로 설정 화면으로 복귀하도록 개선함
- 전화번호 인증 화면: 인증 진행 직전 isLoading이 해제되어 버튼이 잠시 활성화되는 문제가 있었음. 잘못된 추가 입력을 방지하기 위해 loading 상태 변경 타이밍을 수정하여 버튼 비활성화가 안정적으로 유지되도록 개선

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 서버 정상 삭제 확인