### PR TITLE
refact: #197 초기 프로필 세팅뷰, 설정뷰에 유저 정보 싱글톤 적용

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		61C9B19D2E9BEC130007C8F4 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		61C9B19F2E9BED150007C8F4 /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDate.swift; sourceTree = "<group>"; };
+		8B003FDA2EB1DF68005C808E /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B354C7F2EA4A17A0030F9A1 /* UserPairingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPairingStore.swift; sourceTree = "<group>"; };
 		8B5F44552E90FA74003137F2 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		8B5F44572E90FA99003137F2 /* ProfileSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupViewModel.swift; sourceTree = "<group>"; };
@@ -188,7 +189,6 @@
 		CAA9AEF12E8FE3070047A89A /* InviteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewModel.swift; sourceTree = "<group>"; };
 		CAACD3692EA0B8970057827D /* ArchiveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailView.swift; sourceTree = "<group>"; };
 		CAACD36B2EA0C1120057827D /* ArchiveDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailViewModel.swift; sourceTree = "<group>"; };
-		CAB6B13D2EB19A2800F778EC /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		D24402A12E992CCF00D837C8 /* CameraViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewContainer.swift; sourceTree = "<group>"; };
 		D24402A32E992CD800D837C8 /* CaptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionViewModel.swift; sourceTree = "<group>"; };
 		D24402A52E992CD800D837C8 /* CaptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionView.swift; sourceTree = "<group>"; };
@@ -672,7 +672,7 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = CAB6B13D2EB19A2800F778EC /* DonDog-iOS.app */;
+			productReference = 8B003FDA2EB1DF68005C808E /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -188,7 +188,7 @@
 		CAA9AEF12E8FE3070047A89A /* InviteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewModel.swift; sourceTree = "<group>"; };
 		CAACD3692EA0B8970057827D /* ArchiveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailView.swift; sourceTree = "<group>"; };
 		CAACD36B2EA0C1120057827D /* ArchiveDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailViewModel.swift; sourceTree = "<group>"; };
-		CAB6B13D2EB19A2800F778EC /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAB6B13D2EB19A2800F778EC /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		D24402A12E992CCF00D837C8 /* CameraViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewContainer.swift; sourceTree = "<group>"; };
 		D24402A32E992CD800D837C8 /* CaptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionViewModel.swift; sourceTree = "<group>"; };
 		D24402A52E992CD800D837C8 /* CaptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionView.swift; sourceTree = "<group>"; };
@@ -393,7 +393,6 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
-				CAB6B13D2EB19A2800F778EC /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};

--- a/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
@@ -154,12 +154,7 @@ final class AuthService {
                     
                     guard let rid = roomId, !rid.isEmpty else {
                         state.reset()
-                        state.myUid = refreshUser.uid
-                        state.myName = data["name"] as? String
-                        
                         NSLog("[AuthService] 🔓 미연결 상태 (roomId 없음)")
-                        
-                        replaceRootinAuthService(.feed, coordinator: coordinator)
                         return
                     }
                     

--- a/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
@@ -77,16 +77,9 @@ final class AuthService {
                 NSLog("[AuthService] IDToken 분실로 current User 찾을 수 없음 → welcome 화면으로 이동")
                 return
             }
-
+            
             Task { @MainActor in
-                let state = UserPairingStore.shared
-                state.myUid = refreshUser.uid
-                state.myName = nil
-                state.roomId = nil
-                state.partnerUid = nil
-                state.partnerName = nil
-                state.isConnected = false
-                NSLog("[AuthService] 🚀 Primed UserPairingStore with myUid early: uid=\(state.myUid ?? "nil")")
+                UserPairingStore.shared.reset()
             }
             
             // 현재 기기의 FCM 토큰 firestore에 업로드
@@ -154,14 +147,18 @@ final class AuthService {
                 let data = userDoc.data() ?? [:]
                 let roomId = data["roomId"] as? String
                 
-                Task { @MainActor in
+                Task {
                     let state = UserPairingStore.shared
-                    if state.myUid == nil { state.myUid = refreshUser.uid }
+                    state.myUid = refreshUser.uid
                     state.myName = data["name"] as? String
                     
                     guard let rid = roomId, !rid.isEmpty else {
                         state.reset()
+                        state.myUid = refreshUser.uid
+                        state.myName = data["name"] as? String
+                        
                         NSLog("[AuthService] 🔓 미연결 상태 (roomId 없음)")
+                        
                         replaceRootinAuthService(.feed, coordinator: coordinator)
                         return
                     }

--- a/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
@@ -77,9 +77,16 @@ final class AuthService {
                 NSLog("[AuthService] IDToken 분실로 current User 찾을 수 없음 → welcome 화면으로 이동")
                 return
             }
-            
+
             Task { @MainActor in
-                UserPairingStore.shared.reset()
+                let state = UserPairingStore.shared
+                state.myUid = refreshUser.uid
+                state.myName = nil
+                state.roomId = nil
+                state.partnerUid = nil
+                state.partnerName = nil
+                state.isConnected = false
+                NSLog("[AuthService] 🚀 Primed UserPairingStore with myUid early: uid=\(state.myUid ?? "nil")")
             }
             
             // 현재 기기의 FCM 토큰 firestore에 업로드
@@ -147,9 +154,9 @@ final class AuthService {
                 let data = userDoc.data() ?? [:]
                 let roomId = data["roomId"] as? String
                 
-                Task {
+                Task { @MainActor in
                     let state = UserPairingStore.shared
-                    state.myUid = refreshUser.uid
+                    if state.myUid == nil { state.myUid = refreshUser.uid }
                     state.myName = data["name"] as? String
                     
                     guard let rid = roomId, !rid.isEmpty else {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/ProfileSetupViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/ProfileSetupViewModel.swift
@@ -33,8 +33,15 @@ final class ProfileSetupViewModel: ObservableObject {
     
     private let db = Firestore.firestore()
     private let generateInviteCodeService: GenerateCodeService
-    init(generateInviteCodeService: GenerateCodeService = GenerateCodeService()) {
+    
+    private weak var coordinator: AppCoordinator?
+    func attach(coordinator: AppCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    init(generateInviteCodeService: GenerateCodeService = GenerateCodeService(), coordinator: AppCoordinator? = nil) {
         self.generateInviteCodeService = generateInviteCodeService
+        self.coordinator = coordinator
     }
     
     func saveUserProfile() {
@@ -58,6 +65,8 @@ final class ProfileSetupViewModel: ObservableObject {
                 }
             case .success(let inviteCode):
                 self.saveProfile(inviteCode: inviteCode, uid: uid)
+                coordinator?.inviteShowSentHint = true
+                coordinator?.replaceRoot(.invite)
             }
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/ProfileSetupView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/Views/ProfileSetupView.swift
@@ -55,11 +55,8 @@ struct ProfileSetupView: View {
         .padding(.horizontal, 20)
         .dismissKeyboard()
         .backHiddenSwipeEnabled()
-        .onChange(of: viewModel.didComplete, initial: true) { _, newValue in
-            if newValue {
-                coordinator.inviteShowSentHint = true
-                coordinator.replaceRoot(.invite)
-            }
+        .task {
+            viewModel.attach(coordinator: coordinator)
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/ViewModels/InviteViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/ViewModels/InviteViewModel.swift
@@ -23,8 +23,8 @@ final class InviteViewModel: ObservableObject {
     
     @Published var showSentHint: Bool = false
     
-    
     private let db = Firestore.firestore()
+    private let connectUserInfo = UserPairingStore.shared
     private let generateInviteCodeService: GenerateCodeService
     private var timerCancellable: AnyCancellable?
     
@@ -35,10 +35,28 @@ final class InviteViewModel: ObservableObject {
         self.generateInviteCodeService = generateInviteCodeService
     }
     
-    private var currentUserUID: String? {
-        guard let uid = Auth.auth().currentUser?.uid else {
-            self.message = "로그인이 필요합니다"
+//    private var currentUserUID: String? {
+//        guard let myUid = Auth.auth().currentUser?.myUid else {
+//            self.message = "로그인이 필요합니다"
+//            self.isLoading = false
+//            return nil
+//        }
+//        return myUid
+//    }
+    
+    // MARK: - Debug helpers
+    private func debugLog(_ message: String) {
+        print("[InviteViewModel] \(message) | myUid=\(String(describing: connectUserInfo.myUid)) roomId=\(String(describing: connectUserInfo.roomId)))")
+    }
+
+    /// Ensures we never pass an empty path to Firestore's `document("")` which would crash.
+    /// Returns a non-empty myUid or handles UI state and logs, then returns nil.
+    private func ensureMyUid(context: String) -> String? {
+        let uid = connectUserInfo.myUid ?? ""
+        guard !uid.isEmpty else {
+            self.message = "로그인이 필요합니다. 다시 시도해 주세요."
             self.isLoading = false
+            debugLog("❌ [\(context)] myUid is empty. Preventing empty document path.")
             return nil
         }
         return uid
@@ -46,10 +64,11 @@ final class InviteViewModel: ObservableObject {
     
     // MARK: - 내 초대코드 띄우기
     func fetchInviteCodeandExpireDate() {
-        guard let uid = currentUserUID else { return }
         self.isLoading = true
+        
+        debugLog("▶️ fetchInviteCodeandExpireDate: fetching user doc \(connectUserInfo.myUid)")
 
-        db.collection("Users").document(uid).getDocument { [weak self] snap, err in
+        db.collection("Users").document(connectUserInfo.myUid ?? "").getDocument { [weak self] snap, err in
             guard self != nil else { return }
             guard let data = snap?.data(), let snap = snap, snap.exists else {
                 return
@@ -59,7 +78,7 @@ final class InviteViewModel: ObservableObject {
             }
         }
         
-        db.collection("Invites").whereField("inviterUid", isEqualTo: uid).getDocuments { [weak self] result, error in
+        db.collection("Invites").whereField("inviterUid", isEqualTo: connectUserInfo.myUid ?? "").getDocuments { [weak self] result, error in
             guard let self = self else { return }
             DispatchQueue.main.async {
                 if let document = result?.documents.first {
@@ -115,7 +134,7 @@ final class InviteViewModel: ObservableObject {
     }
     
     // MARK: - 다른 사람 초대코드 입력
-    func connectWithInviteCode() {
+    func connectWithInviteCode() async {
         message = ""
         connectSucceeded = false
         isLoading = true
@@ -195,10 +214,9 @@ final class InviteViewModel: ObservableObject {
                 // A) 초대자의 유저 문서에 roomId가 있는 경우 → 기존 방에 내 uid를 참가자로 추가하고, 내 Users 문서에 roomId/createdAt 저장
                 if let existingRoomId = inviterRoomId, !existingRoomId.isEmpty {
                         let roomDoc = self.db.collection("Rooms").document(existingRoomId)
-                        guard let myUid = self.currentUserUID else { return }
-                        let myUserDoc = self.db.collection("Users").document(myUid)
+                    let myUserDoc = self.db.collection("Users").document(self.connectUserInfo.myUid ?? "")
                         
-                    self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: nil, roomId: existingRoomId, participantUids: [myUid]) { err in
+                    self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: nil, roomId: existingRoomId, participantUids: [self.connectUserInfo.myUid ?? ""]) { err in
                         if let err = err {
                             DispatchQueue.main.async {
                                 self.message = "유효하지 않은 초대코드입니다. \(err.localizedDescription)"
@@ -232,9 +250,8 @@ final class InviteViewModel: ObservableObject {
                                 return
                             }
                             
-                            guard let myUid = self.currentUserUID else { return }
-                            let myUserDoc = self.db.collection("Users").document(myUid)
-                            self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: inviterUserDoc, roomId: candidate, participantUids: [inviterUid, myUid]) { err in
+                            let myUserDoc = self.db.collection("Users").document(self.connectUserInfo.myUid ?? "")
+                            self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: inviterUserDoc, roomId: candidate, participantUids: [inviterUid, self.connectUserInfo.myUid ?? ""]) { err in
                                 if let err = err {
                                     DispatchQueue.main.async {
                                         self.message = "문제가 생겼어요. 잠시 후 다시 시도해 주세요. \(err.localizedDescription)"
@@ -259,7 +276,7 @@ final class InviteViewModel: ObservableObject {
     
     private func commitRoomJoin(roomDoc: DocumentReference, myUserDoc: DocumentReference, inviterUserDoc: DocumentReference?, roomId: String, participantUids: [String], completion: @escaping (Error?) -> Void) {
         let saveTgt = db.batch()
-        /// Rooms/{roomId}의 participants에 uid 추가
+        /// Rooms/{roomId}의 participants에 myUid 추가
         saveTgt.setData([
             "participants": participantUids,
             "createdAt": FieldValue.serverTimestamp()
@@ -281,7 +298,6 @@ final class InviteViewModel: ObservableObject {
     
     func refreshInviteCode() {
         self.isLoading = true
-        guard let uid = Auth.auth().currentUser?.uid else { return }
         guard let code = self.inviteCode, !code.isEmpty else { return }
 
         db.collection("Invites").document(code).delete { [weak self] error in
@@ -295,36 +311,39 @@ final class InviteViewModel: ObservableObject {
 
             print("[초대코드 재발급] 기존 코드 삭제 완료")
 
-            self.generateInviteCodeService.generateUniqueInviteCode { result in
-                switch result {
-                case .failure(let err):
-                    print("[초대코드 재발급] 재발급 실패: \(err.localizedDescription)")
-                    self.isLoading = false
-                    
-                case .success(let newCode):
-                    let expireDate = Date().addingTimeInterval(24 * 60 * 60)
-                    let inviteDoc = self.db.collection("Invites").document(newCode)
+            DispatchQueue.main.async {
+                self.generateInviteCodeService.generateUniqueInviteCode { [self] result in
+                    switch result {
+                    case .failure(let err):
+                        print("[초대코드 재발급] 재발급 실패: \(err.localizedDescription)")
+                        self.isLoading = false
+                        
+                    case .success(let newCode):
+                        let expireDate = Date().addingTimeInterval(24 * 60 * 60)
+                        let inviteDoc = self.db.collection("Invites").document(newCode)
 
-                    inviteDoc.setData([
-                        "inviterUid": uid,
-                        "expireDate": expireDate
-                    ]) { err in
-                        if let err = err {
-                            print("[초대코드 재발급] 저장 실패: \(err.localizedDescription)")
-                            self.isLoading = false
-                            return
+                        inviteDoc.setData([
+                            "inviterUid": self.connectUserInfo.myUid ?? "",
+                            "expireDate": expireDate
+                        ]) { err in
+                            if let err = err {
+                                print("[초대코드 재발급] 저장 실패: \(err.localizedDescription)")
+                                self.isLoading = false
+                                return
+                            }
+
+                            print("[초대코드 재발급] 완료 ✅ \(newCode)")
+                            self.inviteCode = newCode
+                            self.stagedInviteText = newCode
+                            self.expireDate = expireDate
+                            self.inviteText = ""
+                            self.startTimer()
+                            // self.isLoading = false
                         }
-
-                        print("[초대코드 재발급] 완료 ✅ \(newCode)")
-                        self.inviteCode = newCode
-                        self.stagedInviteText = newCode
-                        self.expireDate = expireDate
-                        self.inviteText = ""
-                        self.startTimer()
-                        // self.isLoading = false
                     }
                 }
             }
+            
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/ViewModels/InviteViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/ViewModels/InviteViewModel.swift
@@ -44,57 +44,33 @@ final class InviteViewModel: ObservableObject {
 //        return myUid
 //    }
     
-    // MARK: - Debug helpers
-    private func debugLog(_ message: String) {
-        print("[InviteViewModel] \(message) | myUid=\(String(describing: connectUserInfo.myUid)) roomId=\(String(describing: connectUserInfo.roomId)))")
-    }
-
-    /// Ensures we never pass an empty path to Firestore's `document("")` which would crash.
-    /// Returns a non-empty myUid or handles UI state and logs, then returns nil.
-    private func ensureMyUid(context: String) -> String? {
-        let uid = connectUserInfo.myUid ?? ""
-        guard !uid.isEmpty else {
-            self.message = "로그인이 필요합니다. 다시 시도해 주세요."
-            self.isLoading = false
-            debugLog("❌ [\(context)] myUid is empty. Preventing empty document path.")
-            return nil
-        }
-        return uid
-    }
-    
     // MARK: - 내 초대코드 띄우기
     func fetchInviteCodeandExpireDate() {
         self.isLoading = true
-        
-        debugLog("▶️ fetchInviteCodeandExpireDate: fetching user doc \(connectUserInfo.myUid)")
-
-        db.collection("Users").document(connectUserInfo.myUid ?? "").getDocument { [weak self] snap, err in
-            guard self != nil else { return }
-            guard let data = snap?.data(), let snap = snap, snap.exists else {
-                return
-            }
-            DispatchQueue.main.async {
-                self?.userName = (data["name"] as? String) ?? ""
-            }
-        }
-        
-        db.collection("Invites").whereField("inviterUid", isEqualTo: connectUserInfo.myUid ?? "").getDocuments { [weak self] result, error in
+        guard let myUid = connectUserInfo.myUid else { return }
+        db.collection("Invites").whereField("inviterUid", isEqualTo: myUid).getDocuments { [weak self] result, error in
             guard let self = self else { return }
+            let docCount = result?.documents.count ?? 0
+            if let first = result?.documents.first {
+                let expireTS = first.data()["expireDate"] as? Timestamp
+            }
             DispatchQueue.main.async {
                 if let document = result?.documents.first {
                     self.inviteCode = document.documentID
-                    
                     if let lefttime = document.data()["expireDate"] as? Timestamp {
                         self.expireDate = lefttime.dateValue()
                     } else {
                         self.expireDate = nil
                     }
                     self.stagedInviteText = "\(self.inviteCode ?? "")"
-                    self.inviteText = ""
+                    self.inviteText = self.stagedInviteText
                     self.startTimer()
                 } else {
                     self.inviteText = "초대코드를 불러오지 못했습니다."
                 }
+                
+                print("[InviteViewModel] end UI assign | inviteText=\(self.inviteText), remain=\(self.remainTimeText)")
+                
                 self.isLoading = false
             }
         }
@@ -139,6 +115,8 @@ final class InviteViewModel: ObservableObject {
         connectSucceeded = false
         isLoading = true
         allowInviteCodeError = false
+        
+        guard let myUid = connectUserInfo.myUid else { return }
         
         let inputcode = inputInviteCode.trimmingCharacters(in: .whitespacesAndNewlines)
         
@@ -213,10 +191,10 @@ final class InviteViewModel: ObservableObject {
                 let inviterRoomId = inviterDoc?.data()? ["roomId"] as? String
                 // A) 초대자의 유저 문서에 roomId가 있는 경우 → 기존 방에 내 uid를 참가자로 추가하고, 내 Users 문서에 roomId/createdAt 저장
                 if let existingRoomId = inviterRoomId, !existingRoomId.isEmpty {
-                        let roomDoc = self.db.collection("Rooms").document(existingRoomId)
-                    let myUserDoc = self.db.collection("Users").document(self.connectUserInfo.myUid ?? "")
+                    let roomDoc = self.db.collection("Rooms").document(existingRoomId)
+                    let myUserDoc = self.db.collection("Users").document(myUid)
                         
-                    self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: nil, roomId: existingRoomId, participantUids: [self.connectUserInfo.myUid ?? ""]) { err in
+                    self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: nil, roomId: existingRoomId, participantUids: [myUid]) { err in
                         if let err = err {
                             DispatchQueue.main.async {
                                 self.message = "유효하지 않은 초대코드입니다. \(err.localizedDescription)"
@@ -250,8 +228,8 @@ final class InviteViewModel: ObservableObject {
                                 return
                             }
                             
-                            let myUserDoc = self.db.collection("Users").document(self.connectUserInfo.myUid ?? "")
-                            self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: inviterUserDoc, roomId: candidate, participantUids: [inviterUid, self.connectUserInfo.myUid ?? ""]) { err in
+                            let myUserDoc = self.db.collection("Users").document(myUid)
+                            self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: inviterUserDoc, roomId: candidate, participantUids: [inviterUid, myUid]) { err in
                                 if let err = err {
                                     DispatchQueue.main.async {
                                         self.message = "문제가 생겼어요. 잠시 후 다시 시도해 주세요. \(err.localizedDescription)"

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/ViewModels/InviteViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/ViewModels/InviteViewModel.swift
@@ -24,7 +24,6 @@ final class InviteViewModel: ObservableObject {
     @Published var showSentHint: Bool = false
     
     private let db = Firestore.firestore()
-    private let connectUserInfo = UserPairingStore.shared
     private let generateInviteCodeService: GenerateCodeService
     private var timerCancellable: AnyCancellable?
     
@@ -35,42 +34,47 @@ final class InviteViewModel: ObservableObject {
         self.generateInviteCodeService = generateInviteCodeService
     }
     
-//    private var currentUserUID: String? {
-//        guard let myUid = Auth.auth().currentUser?.myUid else {
-//            self.message = "로그인이 필요합니다"
-//            self.isLoading = false
-//            return nil
-//        }
-//        return myUid
-//    }
+    private var currentUserUID: String? {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            self.message = "로그인이 필요합니다"
+            self.isLoading = false
+            return nil
+        }
+        return uid
+    }
     
     // MARK: - 내 초대코드 띄우기
     func fetchInviteCodeandExpireDate() {
+        guard let uid = currentUserUID else { return }
         self.isLoading = true
-        guard let myUid = connectUserInfo.myUid else { return }
-        db.collection("Invites").whereField("inviterUid", isEqualTo: myUid).getDocuments { [weak self] result, error in
-            guard let self = self else { return }
-            let docCount = result?.documents.count ?? 0
-            if let first = result?.documents.first {
-                let expireTS = first.data()["expireDate"] as? Timestamp
+
+        db.collection("Users").document(uid).getDocument { [weak self] snap, err in
+            guard self != nil else { return }
+            guard let data = snap?.data(), let snap = snap, snap.exists else {
+                return
             }
+            DispatchQueue.main.async {
+                self?.userName = (data["name"] as? String) ?? ""
+            }
+        }
+        
+        db.collection("Invites").whereField("inviterUid", isEqualTo: uid).getDocuments { [weak self] result, error in
+            guard let self = self else { return }
             DispatchQueue.main.async {
                 if let document = result?.documents.first {
                     self.inviteCode = document.documentID
+                    
                     if let lefttime = document.data()["expireDate"] as? Timestamp {
                         self.expireDate = lefttime.dateValue()
                     } else {
                         self.expireDate = nil
                     }
                     self.stagedInviteText = "\(self.inviteCode ?? "")"
-                    self.inviteText = self.stagedInviteText
+                    self.inviteText = ""
                     self.startTimer()
                 } else {
                     self.inviteText = "초대코드를 불러오지 못했습니다."
                 }
-                
-                print("[InviteViewModel] end UI assign | inviteText=\(self.inviteText), remain=\(self.remainTimeText)")
-                
                 self.isLoading = false
             }
         }
@@ -110,13 +114,11 @@ final class InviteViewModel: ObservableObject {
     }
     
     // MARK: - 다른 사람 초대코드 입력
-    func connectWithInviteCode() async {
+    func connectWithInviteCode() {
         message = ""
         connectSucceeded = false
         isLoading = true
         allowInviteCodeError = false
-        
-        guard let myUid = connectUserInfo.myUid else { return }
         
         let inputcode = inputInviteCode.trimmingCharacters(in: .whitespacesAndNewlines)
         
@@ -191,8 +193,9 @@ final class InviteViewModel: ObservableObject {
                 let inviterRoomId = inviterDoc?.data()? ["roomId"] as? String
                 // A) 초대자의 유저 문서에 roomId가 있는 경우 → 기존 방에 내 uid를 참가자로 추가하고, 내 Users 문서에 roomId/createdAt 저장
                 if let existingRoomId = inviterRoomId, !existingRoomId.isEmpty {
-                    let roomDoc = self.db.collection("Rooms").document(existingRoomId)
-                    let myUserDoc = self.db.collection("Users").document(myUid)
+                        let roomDoc = self.db.collection("Rooms").document(existingRoomId)
+                        guard let myUid = self.currentUserUID else { return }
+                        let myUserDoc = self.db.collection("Users").document(myUid)
                         
                     self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: nil, roomId: existingRoomId, participantUids: [myUid]) { err in
                         if let err = err {
@@ -228,6 +231,7 @@ final class InviteViewModel: ObservableObject {
                                 return
                             }
                             
+                            guard let myUid = self.currentUserUID else { return }
                             let myUserDoc = self.db.collection("Users").document(myUid)
                             self.commitRoomJoin(roomDoc: roomDoc, myUserDoc: myUserDoc, inviterUserDoc: inviterUserDoc, roomId: candidate, participantUids: [inviterUid, myUid]) { err in
                                 if let err = err {
@@ -254,7 +258,7 @@ final class InviteViewModel: ObservableObject {
     
     private func commitRoomJoin(roomDoc: DocumentReference, myUserDoc: DocumentReference, inviterUserDoc: DocumentReference?, roomId: String, participantUids: [String], completion: @escaping (Error?) -> Void) {
         let saveTgt = db.batch()
-        /// Rooms/{roomId}의 participants에 myUid 추가
+        /// Rooms/{roomId}의 participants에 uid 추가
         saveTgt.setData([
             "participants": participantUids,
             "createdAt": FieldValue.serverTimestamp()
@@ -276,6 +280,7 @@ final class InviteViewModel: ObservableObject {
     
     func refreshInviteCode() {
         self.isLoading = true
+        guard let uid = Auth.auth().currentUser?.uid else { return }
         guard let code = self.inviteCode, !code.isEmpty else { return }
 
         db.collection("Invites").document(code).delete { [weak self] error in
@@ -289,39 +294,36 @@ final class InviteViewModel: ObservableObject {
 
             print("[초대코드 재발급] 기존 코드 삭제 완료")
 
-            DispatchQueue.main.async {
-                self.generateInviteCodeService.generateUniqueInviteCode { [self] result in
-                    switch result {
-                    case .failure(let err):
-                        print("[초대코드 재발급] 재발급 실패: \(err.localizedDescription)")
-                        self.isLoading = false
-                        
-                    case .success(let newCode):
-                        let expireDate = Date().addingTimeInterval(24 * 60 * 60)
-                        let inviteDoc = self.db.collection("Invites").document(newCode)
+            self.generateInviteCodeService.generateUniqueInviteCode { result in
+                switch result {
+                case .failure(let err):
+                    print("[초대코드 재발급] 재발급 실패: \(err.localizedDescription)")
+                    self.isLoading = false
+                    
+                case .success(let newCode):
+                    let expireDate = Date().addingTimeInterval(24 * 60 * 60)
+                    let inviteDoc = self.db.collection("Invites").document(newCode)
 
-                        inviteDoc.setData([
-                            "inviterUid": self.connectUserInfo.myUid ?? "",
-                            "expireDate": expireDate
-                        ]) { err in
-                            if let err = err {
-                                print("[초대코드 재발급] 저장 실패: \(err.localizedDescription)")
-                                self.isLoading = false
-                                return
-                            }
-
-                            print("[초대코드 재발급] 완료 ✅ \(newCode)")
-                            self.inviteCode = newCode
-                            self.stagedInviteText = newCode
-                            self.expireDate = expireDate
-                            self.inviteText = ""
-                            self.startTimer()
-                            // self.isLoading = false
+                    inviteDoc.setData([
+                        "inviterUid": uid,
+                        "expireDate": expireDate
+                    ]) { err in
+                        if let err = err {
+                            print("[초대코드 재발급] 저장 실패: \(err.localizedDescription)")
+                            self.isLoading = false
+                            return
                         }
+
+                        print("[초대코드 재발급] 완료 ✅ \(newCode)")
+                        self.inviteCode = newCode
+                        self.stagedInviteText = newCode
+                        self.expireDate = expireDate
+                        self.inviteText = ""
+                        self.startTimer()
+                        // self.isLoading = false
                     }
                 }
             }
-            
         }
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/Views/InviteView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/Views/InviteView.swift
@@ -17,7 +17,8 @@ struct InviteView: View {
             CustomNavigationBar(leadingType: viewModel.showSentHint ? .none : .back(action: coordinator.pop), centerType: .title(title: "가족 연결"), trailingType: .none, navigationColor: .black)
             
             HStack {
-                Text(UserPairingStore.shared.myName ?? "")
+                Text("\(viewModel.userName ?? "") ")
+                    .font(.titleBold20)
                 + Text("님\n")
                 + Text("이제 가족과 연결해 보세요")
                 
@@ -103,7 +104,7 @@ struct InviteView: View {
             
             Spacer()
             
-            CustomButton(title: "연결하기", isEnable: !viewModel.inputInviteCode.isEmpty && !viewModel.isLoading, action: { Task { await viewModel.connectWithInviteCode() }})
+            CustomButton(title: "연결하기", isEnable: !viewModel.inputInviteCode.isEmpty && !viewModel.isLoading, action: viewModel.connectWithInviteCode)
                 .padding(.bottom, viewModel.showSentHint ? (keyboard.keyboardHeight == 0 ? 0 : -10) : 0)
             
             if viewModel.showSentHint {
@@ -120,9 +121,7 @@ struct InviteView: View {
         .padding(.horizontal, 20)
         .backHiddenSwipeEnabled()
         .dismissKeyboard()
-        .task {
-            viewModel.fetchInviteCodeandExpireDate()
-        }
+        .task { viewModel.fetchInviteCodeandExpireDate() }
         .onChange(of: viewModel.connectSucceeded) {
             coordinator.replaceRoot(.feed)
         }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/Views/InviteView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/Views/InviteView.swift
@@ -17,8 +17,7 @@ struct InviteView: View {
             CustomNavigationBar(leadingType: viewModel.showSentHint ? .none : .back(action: coordinator.pop), centerType: .title(title: "가족 연결"), trailingType: .none, navigationColor: .black)
             
             HStack {
-                Text("\(viewModel.userName ?? "") ")
-                    .font(.titleBold20)
+                Text(UserPairingStore.shared.myName ?? "")
                 + Text("님\n")
                 + Text("이제 가족과 연결해 보세요")
                 
@@ -121,8 +120,8 @@ struct InviteView: View {
         .padding(.horizontal, 20)
         .backHiddenSwipeEnabled()
         .dismissKeyboard()
-        .task { viewModel.fetchInviteCodeandExpireDate()
-            print("myUid=\(UserPairingStore.shared.myUid)")
+        .task {
+            viewModel.fetchInviteCodeandExpireDate()
         }
         .onChange(of: viewModel.connectSucceeded) {
             coordinator.replaceRoot(.feed)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/Views/InviteView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Invite/Views/InviteView.swift
@@ -104,7 +104,7 @@ struct InviteView: View {
             
             Spacer()
             
-            CustomButton(title: "연결하기", isEnable: !viewModel.inputInviteCode.isEmpty && !viewModel.isLoading, action: viewModel.connectWithInviteCode)
+            CustomButton(title: "연결하기", isEnable: !viewModel.inputInviteCode.isEmpty && !viewModel.isLoading, action: { Task { await viewModel.connectWithInviteCode() }})
                 .padding(.bottom, viewModel.showSentHint ? (keyboard.keyboardHeight == 0 ? 0 : -10) : 0)
             
             if viewModel.showSentHint {
@@ -121,7 +121,9 @@ struct InviteView: View {
         .padding(.horizontal, 20)
         .backHiddenSwipeEnabled()
         .dismissKeyboard()
-        .task { viewModel.fetchInviteCodeandExpireDate() }
+        .task { viewModel.fetchInviteCodeandExpireDate()
+            print("myUid=\(UserPairingStore.shared.myUid)")
+        }
         .onChange(of: viewModel.connectSucceeded) {
             coordinator.replaceRoot(.feed)
         }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViewModels/EditProfileViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViewModels/EditProfileViewModel.swift
@@ -33,7 +33,10 @@ final class EditProfileViewModel: ObservableObject {
     func fetchCurrentProfile() {
         errorMessage = nil
 
-        guard let uid = connectUserInfo.myUid else { return }
+        guard let uid = connectUserInfo.myUid else {
+            self.errorMessage = "로그인 상태가 아닙니다. 다시 로그인해 주세요."
+            return
+        }
 
         let docRef = db.collection("Users").document(uid)
         docRef.getDocument { [weak self] snap, err in
@@ -69,7 +72,10 @@ final class EditProfileViewModel: ObservableObject {
             errorMessage = "닉네임을 입력해 주세요."
             return
         }
-        guard let uid = connectUserInfo.myUid else { return }
+        guard let uid = connectUserInfo.myUid else {
+            errorMessage = "로그인 상태가 아닙니다. 다시 로그인해주세요"
+            return
+        }
 
         let userDoc = db.collection("Users").document(uid)
         userDoc.setData([

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViewModels/EditProfileViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Setting/ViewModels/EditProfileViewModel.swift
@@ -20,6 +20,7 @@ final class EditProfileViewModel: ObservableObject {
     @Published private(set) var didChangeFromInitial: Bool = false
 
     private let db = Firestore.firestore()
+    private let connectUserInfo = UserPairingStore.shared
     private var initialName: String = ""
     private var initialRole: Role? = nil
 
@@ -32,10 +33,7 @@ final class EditProfileViewModel: ObservableObject {
     func fetchCurrentProfile() {
         errorMessage = nil
 
-        guard let uid = Auth.auth().currentUser?.uid else {
-            self.errorMessage = "로그인 상태가 아닙니다. 다시 로그인해 주세요."
-            return
-        }
+        guard let uid = connectUserInfo.myUid else { return }
 
         let docRef = db.collection("Users").document(uid)
         docRef.getDocument { [weak self] snap, err in
@@ -71,10 +69,7 @@ final class EditProfileViewModel: ObservableObject {
             errorMessage = "닉네임을 입력해 주세요."
             return
         }
-        guard let uid = Auth.auth().currentUser?.uid else {
-            errorMessage = "로그인 상태가 아닙니다. 다시 로그인해 주세요."
-            return
-        }
+        guard let uid = connectUserInfo.myUid else { return }
 
         let userDoc = db.collection("Users").document(uid)
         userDoc.setData([


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #197 #222 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 제 담당 뷰 중 초기 프로필 세팅뷰, 설정뷰에 유저 정보 싱글톤을 적용했습니다
- 로그인~초대코드 구간에 싱글톤을 적용해봤으나 안되는 구간이 있었습니다. 디버깅 결과, Auth 상태·Users 문서 생성/삭제·라우팅·ViewModel 생성(onAppear) 타이밍이 비동기로 엇갈리며 UserPairingStore가 일시적으로 비어 보이는 구간이 있었습니다. 이 구간은 유저 정보의 정확성과 실시간성이 중요한 초기 구간이기 때문에 안정성을 위해 기존 서버 데이터 fetch 방식을 유지했습니다. (로그인 이후 연결이 완료된 상태에서는 데이터 변경이 거의 없기 때문에, 이후 구간에서는 싱글톤을 통해 닉네임 표시하는 것이 유효해보입니다)
- 최초 회원가입 시 invite뷰가 잠깐 보였다가 자동으로 feed로 이동하는 문제가 있어서, feed로 라우팅하는 부분을 삭제했습니다. 

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작