### PR TITLE
fix: #249 FeedView 무한로딩 해결

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Components/PolaroidSetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Components/PolaroidSetView.swift
@@ -52,7 +52,7 @@ struct PolaroidFrame: View {
                 imageView(image)
                     .cornerRadius(3)
                     .shadow(color: Color.black.opacity(0.15), radius: 3, x: 1, y: 2)
-                    .frame(width: 240, height: 320)
+                    .frame(maxWidth: 240, maxHeight: 320)
                 HStack {
                     VStack(spacing: 0) {
                         HStack {
@@ -85,21 +85,21 @@ struct PolaroidFrame: View {
                             .frame(width: 36, height: 36)
                     }
                 }
-                .frame(width: 240, height: 79)
+                .frame(maxWidth: 240, maxHeight: 79)
                 .padding(.leading, 4)
                 .background(.ddWhite)
             }
-            .frame(width: 272, height: 415)
+            .frame(maxWidth: 272, maxHeight: 415)
             .background(.ddWhite)
             .cornerRadius(6)
             .shadow(color: Color.black.opacity(0.15), radius: 3, x: 1, y: 2)
             Image(uiImage: sticker)
                 .resizable()
                 .scaledToFit()
-                .frame(width: 140, height: 145)
+                .frame(maxWidth: 140, maxHeight: 145)
                 .offset(x: 4)
         }
-        .frame(width: 272, height: 415)
+        .frame(maxWidth: 272, maxHeight: 415)
     }
 }
 
@@ -154,4 +154,8 @@ struct PolaroidSetView: View {
             .zIndex(isTopImage ? 1 : 0)
         }
     }
+}
+
+#Preview {
+    PolaroidSetView(frontImage: DisplayableImage.uiImage(UIImage()), backImage: DisplayableImage.uiImage(UIImage()), name: "", createdAt: "", caption: nil, stickers: nil, selectedStickerType: nil, isMyPost: false)
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -27,6 +27,7 @@ struct CaptionView: View {
                                 .allowsHitTesting(true)
                                 .padding(.trailing, 30)
                         }
+                        .frame(minHeight: 260)
                         .padding(.top, 103)
                     }
                 
@@ -60,7 +61,7 @@ struct CaptionView: View {
                 .padding(.horizontal, 20)
                 
                 Spacer()
-                    .frame(height: 20)
+                    .frame(maxHeight: 20)
                 
                 Button {
                     onReturnToHome()
@@ -99,7 +100,6 @@ struct CaptionView: View {
                     .onTapGesture {
                         isShowCaptionEditor = false
                         isCaptionFocused = false
-                        
                     }
             }
         }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/ViewModels/FeedViewModel.swift
@@ -36,6 +36,23 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
     let connectUserInfo = UserPairingStore.shared
     private let dataManager: DataManagerProtocol = DataManager.shared
     private let imageUtils = ImageUtils()
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        connectUserInfo.$isConnected
+            .dropFirst()
+            .sink { [weak self] isConnected in
+                if isConnected {
+                    print("[FeedViewModel] 연결 상태 변경 감지 - 게시물 로드 시작")
+                    self?.loadTodayPosts()
+                }
+            }
+            .store(in: &cancellables)
+
+        if connectUserInfo.isConnected {
+            loadTodayPosts()
+        }
+    }
     
     func checkIsNotMyPost() {
         guard let roomId = connectUserInfo.roomId, !selectedPostId.isEmpty else {
@@ -186,7 +203,9 @@ final class FeedViewModel: ObservableObject, CameraViewModelDelegate, CaptionVie
         isLoading = true
         isUploading = false
 
-        guard let roomId = connectUserInfo.roomId else { return }
+        guard let roomId = connectUserInfo.roomId else {
+            print("[FeedViewModel.loadTodayPosts] 방 ID 없음 - [SKIP]")
+            return }
         
         Task {
             do {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -21,13 +21,14 @@ struct FeedView: View {
     @State private var showStickerSheet = false
     @State private var showToastView = false
     @State private var toastWorkItem: DispatchWorkItem?
+    @EnvironmentObject var connectState: UserPairingStore
     
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 HStack {
                     Spacer()
-                    if viewModel.connectUserInfo.isConnected == false {
+                    if connectState.isConnected == false {
                         Button {
                             coordinator.push(.setting)
                         } label: {
@@ -74,7 +75,7 @@ struct FeedView: View {
                             .foregroundStyle(.ddPrimaryBlue)
                     }
                     .padding(.top, 280)
-                } else if viewModel.connectUserInfo.isConnected == false {
+                } else if connectState.isConnected == false {
                     VStack {
                         Spacer()
                         Image(systemName: "person.fill.xmark")

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Feed/Views/FeedView.swift
@@ -21,14 +21,13 @@ struct FeedView: View {
     @State private var showStickerSheet = false
     @State private var showToastView = false
     @State private var toastWorkItem: DispatchWorkItem?
-    @EnvironmentObject var connectState: UserPairingStore
     
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 HStack {
                     Spacer()
-                    if connectState.isConnected == false {
+                    if viewModel.connectUserInfo.isConnected == false {
                         Button {
                             coordinator.push(.setting)
                         } label: {
@@ -75,7 +74,7 @@ struct FeedView: View {
                             .foregroundStyle(.ddPrimaryBlue)
                     }
                     .padding(.top, 280)
-                } else if connectState.isConnected == false {
+                } else if viewModel.connectUserInfo.isConnected == false {
                     VStack {
                         Spacer()
                         Image(systemName: "person.fill.xmark")
@@ -263,7 +262,7 @@ struct FeedView: View {
             }
         }
         .onAppear {
-            if !viewModel.isUploading && !viewModel.isLoading {
+            if viewModel.connectUserInfo.isConnected && !viewModel.isUploading && !viewModel.isLoading {
                 viewModel.loadTodayPosts()
             }
         }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #249 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- FeedViewModel에서 연결 상태 감지 변수를 추가해 FeedView 그리는 타이밍 수정

1. FeedViewModel 생성 시 init()에서 UserPairingStore.$isConnected 구독
2. FeedView가 먼저 렌더링되어도 isConnected가 false면 로드하지 않음
3. AuthService에서 isConnected = true로 변경
4. 구독이 변경을 감지해 자동으로 loadTodayPosts() 호출

---
<img width="300" alt="image" src="https://github.com/user-attachments/assets/968402a4-95b6-4b1d-9075-61329a1a29ad" />

--- 
### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 뷰모델에서 새로운 변수를 만들어 싱글톤 -> 새 상태변수에 넘기는 방식으로 다음 액트 때 수정해보도록 하겠습니다
