### PR TITLE
feat: #250 탈퇴 로직 수정 및 포스트뷰 킹피셔 적용

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -132,7 +132,7 @@
 		8BDF769D2E9FDF88007F12BB /* GenerateCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCodeService.swift; sourceTree = "<group>"; };
 		8BFC735E2EA5CB4800B54F03 /* NetworkErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorView.swift; sourceTree = "<group>"; };
 		8BFC73602EA5D18C00B54F03 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
-		8C3F8FAA2EB7487100699BC3 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C3F8FAA2EB7487100699BC3 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8CAD89DA2EA9FD8D004318F0 /* HapticUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticUtils.swift; sourceTree = "<group>"; };
 		8CF3BD732EAE0AE30050003C /* DataManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagerProtocol.swift; sourceTree = "<group>"; };
 		8CF3BD752EAE0EA40050003C /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
@@ -392,7 +392,6 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
-				8C3F8FAA2EB7487100699BC3 /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};

--- a/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
+++ b/DonDog-iOS/DonDog-iOS/Core/Services/AuthService.swift
@@ -84,10 +84,7 @@ final class AuthService {
             self.userDocListenr?.remove()
             self.userDocListenr = userDoc.addSnapshotListener(includeMetadataChanges: true) { [weak self] userDoc, error in
                 guard let self = self else { return }
-                self.handleUserSnapshot(coordinator: coordinator,
-                                        userDoc: userDoc,
-                                        error: error,
-                                        refreshUser: refreshUser)
+                self.handleUserSnapshot(coordinator: coordinator, userDoc: userDoc, error: error, refreshUser: refreshUser)
             }
         }
     }
@@ -119,10 +116,7 @@ final class AuthService {
     }
 
     // MARK: - 라우팅 처리 2: 사용자 문서 스냅샷 처리
-    private func handleUserSnapshot(coordinator: AppCoordinator,
-                                    userDoc: DocumentSnapshot?,
-                                    error: Error?,
-                                    refreshUser: User) {
+    private func handleUserSnapshot(coordinator: AppCoordinator, userDoc: DocumentSnapshot?, error: Error?, refreshUser: User) {
         if AuthService.isAccountDeletionInProgress { return }
 
         // 오류 또는 스냅샷 nil 처리
@@ -156,17 +150,11 @@ final class AuthService {
 
         let data = userDoc.data() ?? [:]
         let roomId = data["roomId"] as? String
-        processRoomRouting(coordinator: coordinator,
-                           refreshUser: refreshUser,
-                           userData: data,
-                           roomId: roomId)
+        processRoomRouting(coordinator: coordinator, refreshUser: refreshUser, userData: data, roomId: roomId)
     }
 
     // MARK: - 라우팅 처리 3:  방/페어링 상태 라우팅
-    private func processRoomRouting(coordinator: AppCoordinator,
-                                    refreshUser: User,
-                                    userData: [String: Any],
-                                    roomId: String?) {
+    private func processRoomRouting(coordinator: AppCoordinator, refreshUser: User, userData: [String: Any], roomId: String?) {
         let state = UserPairingStore.shared
         state.myUid = refreshUser.uid
         state.myName = userData["name"] as? String

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchivePostContainer.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/SubViews/ArchivePostContainer.swift
@@ -5,8 +5,8 @@
 //  Created by 조유진 on 10/19/25.
 //
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 struct ArchivePostContainer: View {
     let url: URL

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Auth/ViewModels/AuthNumberViewModel.swift
@@ -185,21 +185,36 @@ final class AuthNumberViewModel: ObservableObject {
         return Array(unique.values)
     }
 
-    /// 각 Room을 순회하며 마지막 참가자인 경우 전체 삭제, 아니라면 participants에서 uid만 제거한다.
+    /// 각 Room을 순회하며 무조건 방 전체를 삭제한다.
+    /// 단, participants가 2명 이상(=상대방 존재)이면 상대방의 `Users/{uid}.roomId` 필드를 제거한 뒤 방/게시물/댓글/스토리지 파일까지 정리한다.
     private func processRooms(db: Firestore, uid: String, roomRefs: [DocumentReference]) async throws {
         for roomRef in roomRefs {
             let snap = try await roomRef.getDocument()
             guard let data = snap.data(), let parts = data["participants"] as? [String], parts.contains(uid) else { continue }
 
-            if parts.count > 1 {
-                // 여러 명이면 내 uid만 제거
-                try await dataManager.update(path: roomRef.path, data: ["participants": FieldValue.arrayRemove([uid])])
-                // 서버 스냅샷으로 재확인 (실패해도 진행)
-                _ = try? await roomRef.getDocument(source: .server)
-            } else {
-                // 마지막 1명(본인) → 방 전체 삭제
-                try await deleteEntireRoom(roomRef: roomRef)
+            // 상대방 uid 목록(현재 uid 제외)
+            let partnerIds = parts.filter { $0 != uid }
+
+            // participants가 2명 이상이면: 상대방 Users/{uid}.roomId 제거
+            if !partnerIds.isEmpty {
+                for partnerUid in partnerIds {
+                    let partnerUserPath = "Users/\(partnerUid)"
+                    do {
+                        try await dataManager.update(path: partnerUserPath, data: [
+                            "roomId": FieldValue.delete(),
+                            "recentPostId": FieldValue.delete()
+                        ])
+                    } catch {
+                        try? await dataManager.update(path: partnerUserPath, data: [
+                            "roomId": "",
+                            "recentPostId": ""
+                        ])
+                    }
+                }
             }
+
+            // 규칙: 참가자 수와 무관하게 방 전체 삭제
+            try await deleteEntireRoom(roomRef: roomRef)
         }
     }
 
@@ -256,13 +271,6 @@ final class AuthNumberViewModel: ObservableObject {
             let paths = inviterSnap.documents.map { $0.reference.path }
             try await dataManager.batchDelete(paths: paths)
         }
-
-        // 내가 초대받은 문서가 스키마에 있다면 아래와 같이 확장 가능
-        // let inviteeSnap = try await invites.whereField("inviteeUid", isEqualTo: uid).getDocuments()
-        // if !inviteeSnap.isEmpty {
-        //     let paths = inviteeSnap.documents.map { $0.reference.path }
-        //     try await dataManager.batchDelete(paths: paths)
-        // }
     }
 
     /// Users/{uid} 하위 fcmTokens 먼저 삭제 후, Users 문서 삭제
@@ -296,9 +304,7 @@ final class AuthNumberViewModel: ObservableObject {
             return false
         }
     }
-
-    // MARK: - Utilities
-
+    
     /// Firestorage URL 판별
     private func isFirebaseStorageURL(_ s: String) -> Bool {
         s.hasPrefix("https://firebasestorage.googleapis.com") || s.hasPrefix("gs://")

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/PhotoView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/PhotoView.swift
@@ -5,6 +5,7 @@
 //  Created by 이서현 on 10/27/25.
 //
 
+import Kingfisher
 import SwiftUI
 
 struct PhotoView: View {
@@ -39,35 +40,36 @@ struct PhotoView: View {
     
     private struct AsyncPhoto: View {
         let url: URL
+        @State private var loadFailed: Bool = false
+        
         var body: some View {
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case .success(let img):
-                    img
-                        .resizable()
-                        .scaledToFill()
-                        .frame(maxWidth: .infinity)
-                        .aspectRatio(3.0/4.0, contentMode: .fit)
-                        .clipped()
-                        .cornerRadius(10)
-                        .transition(.opacity)
-                case .failure:
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(.ddGray600)
-                        .frame(maxWidth: .infinity)
-                        .aspectRatio(3.0/4.0, contentMode: .fit)
-                        .overlay(Image(systemName: "photo").opacity(0.7))
-                case .empty:
+            KFImage(url)
+                .placeholder {
                     RoundedRectangle(cornerRadius: 10)
                         .fill(.ddGray600.opacity(0.2))
                         .frame(maxWidth: .infinity)
                         .aspectRatio(3.0/4.0, contentMode: .fit)
-                @unknown default:
-                    Color.clear
-                        .frame(maxWidth: .infinity)
-                        .aspectRatio(3.0/4.0, contentMode: .fit)
                 }
-            }
+                .onFailure { _ in
+                    loadFailed = true
+                }
+                .cancelOnDisappear(true)
+                .fade(duration: 0.25)
+                .resizable()
+                .scaledToFill()
+                .frame(maxWidth: .infinity)
+                .aspectRatio(3.0/4.0, contentMode: .fit)
+                .clipped()
+                .cornerRadius(10)
+                .overlay(alignment: .center) {
+                    if loadFailed {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.ddGray600)
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(3.0/4.0, contentMode: .fit)
+                            .overlay(Image(systemName: "photo").opacity(0.7))
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #250 #224 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 방의 첫번째 탈퇴자든, 마지막 탈퇴자든에 상관없이, 둘 중 한명이라도 탈퇴하면 방의 모든 데이터를 지우도록 수정했습니다
- 포스트뷰(게시물 상세뷰) 중 포토뷰에 킹피셔를 적용했습니다. 별개의 이슈지만 테스크가 적어 하나의 pr에 합쳐 보내는 점 양해부탁드립니다... 

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작
- [x] 서버 확인
