### PR TITLE
feat: 현재 시간에 따라 A/B 파트별 게시물만 보여주는 기능 구현

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Components/CustomNavigationBar.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Components/CustomNavigationBar.swift
@@ -35,7 +35,7 @@ enum CustomNavigationBarTrailingType {
     case close(action: () -> Void)
     case menu(items: [CustomNavMenuItem])
     case setting(action: () -> Void)
-    case changeTime(action: () -> Void, time: String)
+    case timeType(time: String)
     case none
 }
 
@@ -163,10 +163,8 @@ struct CustomNavigationBar: View {
                     .frame(width: 24, height: 24)
             }
         
-        case .changeTime(let action, let time):
-            Button(action: action) {
+        case .timeType(let time):
                 Text("\(time)")
-            }
             
         case .none:
             Spacer().frame(width: 24).opacity(0)
@@ -190,7 +188,7 @@ struct CustomNavigationBar: View {
     )
     
     // 홈뷰
-    CustomNavigationBar(leadingType: .none, centerType: .title(title: "LOGO"), trailingType: .changeTime(action: {}, time: "낮"), navigationColor: .black)
+    CustomNavigationBar(leadingType: .none, centerType: .title(title: "LOGO"), trailingType: .timeType(time: "낮"), navigationColor: .black)
     
     // 카메라 상세 - 촬영
     CustomNavigationBar(leadingType: .back(action: {}), centerType: .none, trailingType: .none, navigationColor: .black)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/ViewModels/HomeViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/ViewModels/HomeViewModel.swift
@@ -17,7 +17,12 @@ final class HomeViewModel: ObservableObject, CaptionViewModelDelegate {
             currentIndex = 0
         }
     }
-    @Published var isShowingATimePost: Bool = true
+    
+    @Published var isShowingATimePost: Bool = true {
+        didSet {
+            updateTimeTypeFromCurrentTime()
+        }
+    }
     @Published var todayPosts: [HomePost] = []
     @Published var currentPost: HomePost?
     @Published var isLoading: Bool = false
@@ -26,8 +31,14 @@ final class HomeViewModel: ObservableObject, CaptionViewModelDelegate {
     let connectUserInfo = UserPairingStore.shared
     private let dataManager: DataManagerProtocol = DataManager.shared
     private var cancellables = Set<AnyCancellable>()
+    private var timeCheckTimer: Timer?
     
     init() {
+        updateTimeTypeFromCurrentTime()
+        timeCheckTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { [weak self] _ in
+            self?.updateTimeTypeFromCurrentTime()
+        }
+        
         connectUserInfo.$isConnected
             .dropFirst()
             .sink { [weak self] isConnected in
@@ -94,13 +105,18 @@ final class HomeViewModel: ObservableObject, CaptionViewModelDelegate {
             .first
     }
     
+    private func updateTimeTypeFromCurrentTime() {
+        let currentIsATime = DateUtils.isATime(date: Date())
+        if isShowingATimePost != currentIsATime {
+            DispatchQueue.main.async { [weak self] in
+                self?.isShowingATimePost = currentIsATime
+            }
+        }
+    }
+    
     func togglePostType() {
         isShowingMyPost.toggle()
         currentIndex = 0
-    }
-    
-    func toggleTimeType() {
-        isShowingATimePost.toggle()
     }
     
     func didStartUploading() {
@@ -112,5 +128,9 @@ final class HomeViewModel: ObservableObject, CaptionViewModelDelegate {
         Task {
             await loadPosts()
         }
+    }
+    
+    deinit {
+        timeCheckTimer?.invalidate()
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -15,7 +15,7 @@ struct HomeView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            CustomNavigationBar(leadingType: .none, centerType: .title(title: "LOGO"), trailingType: .changeTime(action: { viewModel.toggleTimeType() }, time: viewModel.isShowingATimePost ? "낮" : "밤"), navigationColor: .black)
+            CustomNavigationBar(leadingType: .none, centerType: .title(title: "LOGO"), trailingType: .timeType(time: viewModel.isShowingATimePost ? "낮" : "밤"), navigationColor: .black)
                 .padding(.horizontal, 16)
             
             CustomSegmentedControl(items: ArchiveSegment.allCases, selectedItem: $viewModel.selectedPostType, titleProvider: { $0.rawValue })


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #289 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 현재 시간에 따라 A/B 파트별 게시물만 보여주는 기능 구현했습니다
- 1분마다 타임 새로고침해서 앱을 껐다켜지 않아도 A -> B 타임 바뀌도록 구현
- 네비게이션 버튼 삭제 -> 텍스트로 변경

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


<img width="300" alt="IMG_9895" src="https://github.com/user-attachments/assets/bddf3533-186d-42b2-809f-871404160d91" />
<img width="300" alt="IMG_9896" src="https://github.com/user-attachments/assets/f6eba08d-9b02-4f2b-b353-03ecf8a55f25" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 기기 시간을 변경해서 테스트

---