### PR TITLE
fix: #348 게시물에 스티커 붙일 때 SheetView 스티커가 깜빡거리는 오류, 스티커 시트에서 만든 스티커가 reload안되는 문제, 만든 후 돌아올 때 2/3번째 탭으로 안 돌아오는 문제 수정

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -133,7 +133,6 @@
 		61C9B19D2E9BEC130007C8F4 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		61C9B19F2E9BED150007C8F4 /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		61C9B1A52E9BFCBE0007C8F4 /* ArchiveDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDate.swift; sourceTree = "<group>"; };
-		8B102CC62ECF441C00736A01 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8B38DBE12EBCFB5800DD7562 /* PhotoPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerViewModel.swift; sourceTree = "<group>"; };
 		8B5F44552E90FA74003137F2 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		8B5F44592E90FF95003137F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -179,7 +178,7 @@
 		8C3E791E2EBB2895000ADEF6 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		8C3E79212EBB28EF000ADEF6 /* HomePost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePost.swift; sourceTree = "<group>"; };
 		8C3F8FBE2EB8DAAD00699BC3 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
-		8C43E0A32ECF4B8E00A9D6C6 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C43E0A32ECF4B8E00A9D6C6 /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
 		8C5A1ED92ECD57DB00C08B0E /* NotConnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotConnectedView.swift; sourceTree = "<group>"; };
 		8C5A1EDB2ECD589400C08B0E /* TabItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabItemView.swift; sourceTree = "<group>"; };
 		8C5A1EDD2ECD5B5E00C08B0E /* HomeEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeEmptyView.swift; sourceTree = "<group>"; };
@@ -564,7 +563,6 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
-				8C43E0A32ECF4B8E00A9D6C6 /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -837,7 +835,6 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8B102CC62ECF441C00736A01 /* DonDog-iOS.app */;
 			productReference = 8C43E0A32ECF4B8E00A9D6C6 /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};

--- a/DonDog-iOS/DonDog-iOS/Presentation/Components/SitckerGrid.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Components/SitckerGrid.swift
@@ -87,7 +87,7 @@ struct StickerCellView: View {
     let url: URL?
     let isLoading: Bool
     let isSelected: Bool
-    let hasSelection: Bool
+    let hasSelection: Bool?
     let index: Int
     let categoryKey: String?
     let role: String?
@@ -99,7 +99,7 @@ struct StickerCellView: View {
         
         let order = index + 1
         let stateSuffix: String
-        if hasSelection {
+        if hasSelection == true {
             stateSuffix = isSelected ? "off" : "on"
         } else {
             stateSuffix = "on"
@@ -123,13 +123,7 @@ struct StickerCellView: View {
     
     var body: some View {
         if let url {
-            ZStack {
-                KFImage(url)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 120, height: 100, alignment: .center)
-                    .onTapGesture(perform: onTapLoaded)
-                
+            VStack(spacing: 4) {
                 if isLoading {
                     ZStack {
                         ProgressView()
@@ -144,13 +138,14 @@ struct StickerCellView: View {
                     KFImage(url)
                         .resizable()
                         .scaledToFit()
-                        .opacity(hasSelection ? (isSelected ? 1.0 : 0.5) : 1.0)
+                        .opacity(hasSelection == true ? (isSelected ? 1.0 : 0.5) : 1.0)
                         .frame(width: 120, height: 100, alignment: .center)
                         .onTapGesture(perform: onTapLoaded)
                 }
                 
                 Text(title)
                     .font(.polaroidCaptionRegular16)
+                    .foregroundColor(showedAt == .sheet ? .ppGray200 : .ppBlack)
             }
         } else if isLoading {
             ZStack {
@@ -170,7 +165,6 @@ struct StickerCellView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 120, height: 100)
-                        // .opacity(hasSelection ? (isSelected ? 1.0 : 0.5) : 1.0)
                 } else {
                     ZStack {
                         Circle()

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -14,7 +14,7 @@ struct HomeView: View {
     @StateObject private var cameraViewModel = CameraViewModel()
     @StateObject private var stickerViewModel = StickerViewModel()
     @EnvironmentObject var connectUserInfo: UserPairingStore
-    @StateObject var stickerGridService = StickerGridService()
+    @ObservedObject var stickerGridService = StickerGridService.shared
     
     var body: some View {
         if connectUserInfo.isConnected == .unknown {
@@ -92,6 +92,9 @@ struct HomeView: View {
                                         Task {
                                             await stickerViewModel.fetchStickers()
                                         }
+                                    }
+                                    if let firstCategory = StickerCategory.allCases.first {
+                                        stickerGridService.selectedCategory = firstCategory
                                     }
                                     viewModel.isShowStickerSheet = true
                                 } label: {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -14,6 +14,7 @@ struct HomeView: View {
     @StateObject private var cameraViewModel = CameraViewModel()
     @StateObject private var stickerViewModel = StickerViewModel()
     @EnvironmentObject var connectUserInfo: UserPairingStore
+    @StateObject var stickerGridService = StickerGridService()
     
     var body: some View {
         if connectUserInfo.isConnected == .unknown {
@@ -182,18 +183,26 @@ struct HomeView: View {
                 Task {
                     await viewModel.loadPosts()
                 }
+                
+                if stickerViewModel.shouldReopenSheetAfterCamera {
+                    stickerViewModel.shouldReopenSheetAfterCamera = false
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        viewModel.isShowStickerSheet = true
+                    }
+                }
             }
             .sheet(isPresented: $viewModel.isShowStickerSheet) {
                 if let currentPost = viewModel.currentPost {
                     StickerSheetView(
-                        viewModel: stickerViewModel, postId: currentPost.postId,
+                        stickerViewModel: stickerViewModel, postId: currentPost.postId,
                         onRequestCamera: {
                             stickerViewModel.shouldReopenSheetAfterCamera = true
                             viewModel.isShowStickerSheet = false
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                 coordinator.push(.camera(isStickerCamera: true))
                             }
-                        }, gridService: StickerGridService()
+                        }, gridService: stickerGridService
                     )
                     .presentationDetents([.height(317)])
                     .presentationBackgroundInteraction(.enabled)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
@@ -15,7 +15,7 @@ struct StickerSheetView: View {
     let postId: String
     let onRequestCamera: () -> Void
     
-    @State private var select = 0
+    @State private var select: Int
     @Environment(\.dismiss) var dismiss
     private let categories = StickerCategory.allCases
     
@@ -33,6 +33,10 @@ struct StickerSheetView: View {
         self.postId = postId
         self.onRequestCamera = onRequestCamera
         self._gridService = ObservedObject(wrappedValue: gridService)
+        
+        let allCategories = StickerCategory.allCases
+        let initialIndex = allCategories.firstIndex(of: gridService.selectedCategory) ?? 0
+        self._select = State(initialValue: initialIndex)
     }
 
     var body: some View {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 import SwiftUI
 
 struct StickerSheetView: View {
-    @ObservedObject var viewModel: StickerViewModel
+    @ObservedObject var stickerViewModel: StickerViewModel
     let postId: String
     let onRequestCamera: () -> Void
     
@@ -19,17 +19,17 @@ struct StickerSheetView: View {
     @Environment(\.dismiss) var dismiss
     private let categories = StickerCategory.allCases
     
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 3)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: -10), count: 3)
     @StateObject private var cameraVM = CameraViewModel()
     @ObservedObject private var gridService: StickerGridService
     
     init(
-        viewModel: StickerViewModel,
+        stickerViewModel: StickerViewModel,
         postId: String,
         onRequestCamera: @escaping () -> Void,
         gridService: StickerGridService
     ) {
-        self.viewModel = viewModel
+        self.stickerViewModel = stickerViewModel
         self.postId = postId
         self.onRequestCamera = onRequestCamera
         self._gridService = ObservedObject(wrappedValue: gridService)
@@ -46,22 +46,28 @@ struct StickerSheetView: View {
                     columns: columns,
                     rowSpacing: 8,
                     onItemAppear: { id in
-                        if let item = gridService.stickerItems(for: gridService.selectedCategory).first(where: { $0.id == id }) {
-                            Task { await gridService.fetchStickerImage(for: item, in: gridService.selectedCategory) }
+                        guard gridService.stickerImageURLs[id] == nil, gridService.loadingItemIDs.contains(id) == false, let item = gridService.stickerItems(for: gridService.selectedCategory).first(where: { $0.id == id }) else { return }
+                        
+                        Task {
+                            await gridService.fetchStickerImage(for: item, in: gridService.selectedCategory)
                         }
                     },
                     onItemTap: { item in
                         if let url = gridService.stickerImageURLs[item.id] {
-                            viewModel.targetItemID = item.id
-                            viewModel.addSticker(with: url)
+                            stickerViewModel.targetItemID = item.id
+                            stickerViewModel.addSticker(with: url)
                         }
                     },
                     onPlusTap: { item in
                         let keyword = item.title
-                        StickerEmotionTagManager.shared.emotionTags = [gridService.selectedCategory.rawValue, keyword]
-                        viewModel.targetItemID = item.id
+                        StickerEmotionTagManager.shared.emotionTags = [
+                            gridService.selectedCategory.rawValue,
+                            keyword
+                        ]
                         onRequestCamera()
                     },
+                    categoryKey: gridService.selectedCategory.assetKey,
+                    role: UserPairingStore.shared.myRole
                 )
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -86,8 +92,8 @@ struct StickerSheetView: View {
                             dismiss()
                             
                             Task {
-                                await viewModel.saveStickers()
-                                viewModel.selectedStickerID = nil
+                                await stickerViewModel.saveStickers()
+                                stickerViewModel.selectedStickerID = nil
                             }
                         } label: {
                             Image(systemName: "checkmark")


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #348 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- StickerGridService를 StateObject로 선언하여 새로운 인스턴스를 만들지 않도록 수정하여 고쳤습니다. 