### PR TITLE
feat: #362 디자인 QA 반영 및 딥링크 수정

### DIFF
--- a/DonDog-iOS/DonDog-iOS/App/AppDelegate.swift
+++ b/DonDog-iOS/DonDog-iOS/App/AppDelegate.swift
@@ -113,13 +113,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         completionHandler([.banner, .sound, .badge])
     }
     
-    // 푸시 알림을 누르면 포함된 link의 정보를 추출하여 딥링크 수행
+    // 푸시 알림을 누르면 포함된 userInfo를 그대로 전달하여 딥링크 수행
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
         NSLog("tapped notification: \(userInfo)")
-        if let link = userInfo["link"] as? String {
-            NotificationCenter.default.post(name: .openDeepLink, object: link)
-        }
+        NotificationCenter.default.post(name: .openDeepLink, object: userInfo)
         completionHandler()
     }
     

--- a/DonDog-iOS/DonDog-iOS/App/Coordinator/AppCoordinator.swift
+++ b/DonDog-iOS/DonDog-iOS/App/Coordinator/AppCoordinator.swift
@@ -22,6 +22,7 @@ final class AppCoordinator: ObservableObject {
     @Published var authShowWithdraw: Bool = false
     @Published var authNumberShowWithdraw: Bool = false
     @Published var showCameraInDeeplink: Bool = false
+    @Published var navigateToMyPost: Bool = false
     
     private var notificationToken: NSObjectProtocol?
     var sessionKey: String { Auth.auth().currentUser?.uid ?? "loggedout" }
@@ -38,9 +39,9 @@ final class AppCoordinator: ObservableObject {
         ) { [weak self] note in
             guard
                 let self,
-                let deeplink = note.object as? String
+                let userInfo = note.object as? [AnyHashable: Any]
             else { return }
-            self.handleDeepLink(deeplink)
+            self.handleNotificationPayload(userInfo)
         }
         
     }
@@ -109,8 +110,26 @@ final class AppCoordinator: ObservableObject {
         }
     }
     
-    func handleDeepLink(_ urlString: String) {
-        guard let url = URL(string: urlString), let scheme = url.scheme, scheme == "dondog" else { return }
+    func handleNotificationPayload(_ userInfo: [AnyHashable: Any]) {
+        // 스티커 알림은 HomeView의 '내 사진' 탭으로 이동
+        if let kind = userInfo["kind"] as? String, kind == "sticker" {
+            if root != .home {
+                replaceRoot(.home)
+            } else {
+                popToRoot()
+            }
+            self.navigateToMyPost = true
+            return
+        }
+        
+        // 그 외 모든 알림은 기존 딥링크 URL 기반으로 처리
+        if let link = userInfo["link"] as? String, let url = URL(string: link) {
+            handleDeepLink(url: url)
+        }
+    }
+    
+    func handleDeepLink(url: URL) {
+        guard url.scheme == "dondog" else { return }
         
         // 모든 딥링크는 홈에서 시작
         if root != .home {
@@ -122,9 +141,7 @@ final class AppCoordinator: ObservableObject {
         switch url.host {
         case "camera":
             self.showCameraInDeeplink = true
-            
         default:
-            // 처리할 수 없는 host일 경우 피드로 이동
             break
         }
     }

--- a/DonDog-iOS/DonDog-iOS/App/PicPeekApp.swift
+++ b/DonDog-iOS/DonDog-iOS/App/PicPeekApp.swift
@@ -22,9 +22,7 @@ struct PicPeekApp: App {
                     if Auth.auth().canHandle(url) {
                         return
                     }
-                    
-                    guard let scheme = url.scheme, scheme == "dondog" else { return }
-                    coordinator.handleDeepLink(url.absoluteString)
+                    coordinator.handleDeepLink(url: url)
                 }
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/ArchiveView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Archive/Views/ArchiveView.swift
@@ -112,6 +112,7 @@ struct ArchiveView: View {
                                             .padding(.horizontal, 10)
                                         }
                                     }
+                                    .padding(.bottom, 100)
                                 }
                                 .padding(.top, 20)
                             }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -260,6 +260,14 @@ struct HomeView: View {
                     isStickerCamera: false
                 )
             }
+            .onReceive(coordinator.$navigateToMyPost) { navigate in
+                if navigate {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        viewModel.selectedPostType = .myArchive
+                        coordinator.navigateToMyPost = false
+                    }
+                }
+            }
             .overlay {
                 if viewModel.isShowToast {
                     VStack {


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #362 

---

### 🧶 주요 변경 내용 (Summary)
- ArchiveView 스크롤 하단 여백 추가

- 스티커 알림 수신 시 HomeView에서 '내 사진'으로 포커싱 되도록 로직 수정
- 딥링크 및 푸시 알림 처리 로직을 AppCoordinator로 중앙화
- handleNotificationPayload에서 푸시 알림 페이로드 직접 처리 (알림 종류 구분)

---

### 📸 스크린샷 (Optional)
[ArchiveView 스크롤 뷰 여백]

https://github.com/user-attachments/assets/38efeb84-6d31-4202-8882-62f081ff021c

[스티커 알림 수신 시 HomeView의 내 사진으로 이동]

https://github.com/user-attachments/assets/d887ec2e-d83f-42f1-8d16-4ef0343e2528

[스티커 알림 수신 시 HomeView의 내 사진으로 이동 - 앱 실행 중 동작(포그라운드 환경)]

https://github.com/user-attachments/assets/8237618f-c9f3-462e-815d-e1f283625999

---

### 🧪 테스트 / 검증 내역

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작

---

### 💬 기타 공유 사항
- 최종 QA 수정사항 반영 후 배포한 환경에서도 푸시알림 테스트 진행할 예정입니다!