### PR TITLE
design: #365 스티커 편집 최종 QA 반영

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -226,11 +226,9 @@ struct HomeView: View {
             .onChange(of: viewModel.isShowStickerSheet) {
                 if !viewModel.isShowStickerSheet {
                     Task {
-                        if stickerViewModel.isStickerAttached {
-                            await stickerViewModel.saveStickers()
-                        }
-                        stickerViewModel.selectedStickerID = nil
+                        await stickerViewModel.saveStickers()
                     }
+                    stickerViewModel.selectedStickerID = nil
                 }
             }
             .background {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
@@ -95,11 +95,9 @@ struct StickerSheetView: View {
                         Button {
                             dismiss()
                             Task {
-                                if stickerViewModel.isStickerAttached {
-                                    await stickerViewModel.saveStickers()
-                                }
-                                stickerViewModel.selectedStickerID = nil
+                                await stickerViewModel.saveStickers()
                             }
+                            stickerViewModel.selectedStickerID = nil
                         } label: {
                             Image(systemName: "checkmark")
                                 .font(.captionRegular13)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
@@ -95,11 +95,9 @@ struct TabItemView: View {
                             .onTapGesture {
                                 isEditing = false
                                 Task {
-                                    if viewModel.isStickerAttached {
-                                        await viewModel.saveStickers()
-                                    }
-                                    viewModel.selectedStickerID = nil
+                                    await viewModel.saveStickers()
                                 }
+                                viewModel.selectedStickerID = nil
                             }
                             .gesture(
                                 DragGesture(minimumDistance: 0)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
@@ -122,6 +122,7 @@ struct TabItemView: View {
                                 }
                             }
                         )
+                        .zIndex(viewModel.selectedStickerID == sticker.id ? 1: 0)
                         .onTapGesture {
                             if isEditing {
                                 viewModel.selectedStickerID = sticker.id

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/ViewModels/StickerViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/ViewModels/StickerViewModel.swift
@@ -31,8 +31,6 @@ final class StickerViewModel: ObservableObject {
     @Published var postId = ""
     @Published var postImageType: PostImageType = .front
     
-    // @Published var itemsByCategory: [StickerCategory: [StickerItem]] = StickerCategoryData.itemsByCategory
-    
     @Published var frontStickers: [AttachedSticker] = []
     @Published var backStickers: [AttachedSticker] = []
     @Published var selectedStickerID: UUID?
@@ -48,15 +46,17 @@ final class StickerViewModel: ObservableObject {
     let dataManager: DataManagerProtocol = DataManager.shared
     let connectUserInfo = UserPairingStore.shared
     var roomId: String = ""
+    private var cancellables = Set<AnyCancellable>()
     
     private var offsetIndex = [0, 0]
     
     init() {
-        guard let id = connectUserInfo.roomId else {
-            print("roomId 가져오기 실패")
-            return
-        }
-        self.roomId = id
+        UserPairingStore.shared.$roomId
+            .compactMap { $0 }
+            .sink { [weak self] id in
+                self?.roomId = id
+            }
+            .store(in: &cancellables)
     }
     
     func fetchStickers() async {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/ViewModels/StickerViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/ViewModels/StickerViewModel.swift
@@ -164,20 +164,23 @@ final class StickerViewModel: ObservableObject {
             }
         }
         
-        let postData: [String: Any] = [
-            "stickerUpdatedAt": Date.now
-        ]
-        
-        do {
-            try await dataManager.batchUpdate([
-                .update(
-                    path: "Rooms/\(roomId)/posts/\(postId)",
-                    data: postData
-                )
-            ])
-        } catch {
-            print("stickerUdpatedAt 최신화 실패: \(error.localizedDescription)")
+        if isStickerAttached {
+            let postData: [String: Any] = [
+                "stickerUpdatedAt": Date.now
+            ]
+            
+            do {
+                try await dataManager.batchUpdate([
+                    .update(
+                        path: "Rooms/\(roomId)/posts/\(postId)",
+                        data: postData
+                    )
+                ])
+            } catch {
+                print("stickerUdpatedAt 최신화 실패: \(error.localizedDescription)")
+            }
+            
+            isStickerAttached = false
         }
-        isStickerAttached = false
     }
 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/StickerView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/StickerView.swift
@@ -41,16 +41,22 @@ struct StickerView: View {
             
             if isEditable && isSelected {
                 Button(action: onDelete) {
-                    Image(systemName: "trash.fill")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 14, height: 16)
-                        .foregroundColor(.ddBlack)
-                        .background(
-                            Circle()
-                                .fill(.ddWhite)
-                                .frame(width: 25, height: 25)
-                        )
+                    ZStack {
+                        Rectangle()
+                            .tint(.clear)
+                            .frame(width: 44, height: 44)
+                        
+                        Image(systemName: "trash.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 14, height: 16)
+                            .foregroundColor(.ddBlack)
+                            .background(
+                                Circle()
+                                    .fill(.ddWhite)
+                                    .frame(width: 25, height: 25)
+                            )
+                    }
                 }
                 .offset(x: -65 * (sticker.scale * gestureScale), y: -55 * (sticker.scale * gestureScale))
                 
@@ -64,6 +70,7 @@ struct StickerView: View {
                             .fill(.ddBlack)
                             .frame(width: 25, height: 25)
                     )
+                    .frame(width: 44, height: 44)
                     .offset(x: 65 * (sticker.scale * gestureScale), y: 55 * (sticker.scale * gestureScale))
                     .gesture(transformGesture)
             }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #365 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 스티커 불러오기 오류 해결
- 쓰레기통 버튼, 크기/기울기 변경 이미지 탭 가능 영역 넓히기
- 스티커 편집시 누른 스티커가 Z스택 최상단에 위치하도록 변경
- 스티커 이동 및 크기/기울기 변경 시 저장

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 다들 고생 많으셨습니다.