### PR TITLE
feat: #359 최종 QA 수정사항 반영

### DIFF
--- a/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
+++ b/DonDog-iOS/DonDog-iOS.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 		8C5A1EDB2ECD589400C08B0E /* TabItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabItemView.swift; sourceTree = "<group>"; };
 		8C5A1EDD2ECD5B5E00C08B0E /* HomeEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeEmptyView.swift; sourceTree = "<group>"; };
 		8C95EAFA2ECF636B0045A2BD /* PinchZoomUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchZoomUtils.swift; sourceTree = "<group>"; };
-		8C95EB042ED038CD0045A2BD /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "DonDog-iOS.app"; path = "/Users/judy/Desktop/Swift-Ch/2025-C6-M11-DONDOG/DonDog-iOS/build/Debug-iphoneos/DonDog-iOS.app"; sourceTree = "<absolute>"; };
+		8C95EB122ED0919F0045A2BD /* DonDog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DonDog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CAD89DA2EA9FD8D004318F0 /* HapticUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticUtils.swift; sourceTree = "<group>"; };
 		8CF3BD732EAE0AE30050003C /* DataManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagerProtocol.swift; sourceTree = "<group>"; };
 		8CF3BD752EAE0EA40050003C /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
@@ -562,6 +562,7 @@
 			isa = PBXGroup;
 			children = (
 				CAA9AED52E8FC15C0047A89A /* DonDog-iOS */,
+				8C95EB122ED0919F0045A2BD /* DonDog-iOS.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -835,7 +836,7 @@
 				8B822D7B2EAB617800D708D7 /* Kingfisher */,
 			);
 			productName = "DonDog-iOS";
-			productReference = 8C95EB042ED038CD0045A2BD /* DonDog-iOS.app */;
+			productReference = 8C95EB122ED0919F0045A2BD /* DonDog-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Extensions/CameraViewController+State.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Extensions/CameraViewController+State.swift
@@ -35,7 +35,7 @@ extension CustomCameraViewController {
             if isConfirmed {
                 self.step1Label.isHidden = true
                 self.step1CheckmarkImageView.isHidden = false
-                self.step1Circle.backgroundColor = .ddAlert
+                self.step1Circle.backgroundColor = .ppSubPrime
                 
                 // Step 1 펄스 애니메이션 멈춤
                 self.step1PulseView.isHidden = true
@@ -64,7 +64,7 @@ extension CustomCameraViewController {
             if isConfirmed {
                 self.step2Label.isHidden = true
                 self.step2CheckmarkImageView.isHidden = false
-                self.step2Circle.backgroundColor = .ddAlert
+                self.step2Circle.backgroundColor = .ppSubPrime
                 
                 // Step 2 펄스 애니메이션 멈춤
                 self.step2PulseView.isHidden = true
@@ -114,12 +114,12 @@ extension CustomCameraViewController {
             
             self.step1Label.isHidden = false
             self.step1CheckmarkImageView.isHidden = true
-            self.step1Circle.backgroundColor = .ddAlert
+            self.step1Circle.backgroundColor = .ppSubPrime
             self.step1Label.textColor = .white
             
             self.step2Label.isHidden = false
             self.step2CheckmarkImageView.isHidden = true
-            self.step2Circle.backgroundColor = .ddGray300
+            self.step2Circle.backgroundColor = .ppSubPrime
             self.step2Label.textColor = .white
             
             self.bottomButtonContainer.isHidden = true

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Extensions/CameraViewController+StepIndicator.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Camera/Extensions/CameraViewController+StepIndicator.swift
@@ -29,7 +29,7 @@ extension CustomCameraViewController {
     }
     
     func setupStep1Circle() {
-        step1PulseView.backgroundColor = UIColor.ddAlert.withAlphaComponent(0.7)
+        step1PulseView.backgroundColor = UIColor.ppSubPrime.withAlphaComponent(0.7)
         step1PulseView.layer.cornerRadius = 12
         stepIndicatorContainer.addSubview(step1PulseView)
         step1PulseView.translatesAutoresizingMaskIntoConstraints = false
@@ -41,7 +41,7 @@ extension CustomCameraViewController {
         ])
         step1PulseView.isHidden = true
         
-        step1Circle.backgroundColor = .ddAlert
+        step1Circle.backgroundColor = .ppSubPrime
         step1Circle.layer.cornerRadius = 12
         stepIndicatorContainer.addSubview(step1Circle)
         step1Circle.translatesAutoresizingMaskIntoConstraints = false
@@ -65,7 +65,7 @@ extension CustomCameraViewController {
         
         step1TextLabel.text = "셀카 촬영"
         step1TextLabel.font = UIFont(name: FontName.pretendardMedium.rawValue, size: 14) ?? UIFont.systemFont(ofSize: 14, weight: .medium)
-        step1TextLabel.textColor = .ddAlert
+        step1TextLabel.textColor = .ppSubPrime
         step1TextLabel.textAlignment = .center
         stepIndicatorContainer.addSubview(step1TextLabel)
         step1TextLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -108,7 +108,7 @@ extension CustomCameraViewController {
         for i in 0..<dotsCount {
             let dot = UIView()
             let alpha = 1.0 - (CGFloat(i) * 0.08)
-            dot.backgroundColor = UIColor.ddAlert.withAlphaComponent(alpha)
+            dot.backgroundColor = UIColor.ppSubPrime.withAlphaComponent(alpha)
             dot.layer.cornerRadius = 2
             stepDotsContainer.addSubview(dot)
             dot.translatesAutoresizingMaskIntoConstraints = false
@@ -126,22 +126,22 @@ extension CustomCameraViewController {
         for (index, dot) in dots.enumerated() {
             if isCapturingFront {
                 let alpha = 1.0 - (CGFloat(index) * 0.08)
-                dot.backgroundColor = UIColor.ddAlert.withAlphaComponent(alpha)
+                dot.backgroundColor = UIColor.ppSubPrime.withAlphaComponent(alpha)
             } else {
                 let alpha = 0.2 + (CGFloat(index) * 0.08)
-                dot.backgroundColor = UIColor.ddAlert.withAlphaComponent(alpha)
+                dot.backgroundColor = UIColor.ppSubPrime.withAlphaComponent(alpha)
             }
         }
     }
     
     func setupStep2Circle() {
-        step2PulseView.backgroundColor = UIColor.ddAlert.withAlphaComponent(0.7)
+        step2PulseView.backgroundColor = UIColor.ppSubPrime.withAlphaComponent(0.7)
         step2PulseView.layer.cornerRadius = 12
         stepIndicatorContainer.addSubview(step2PulseView)
         step2PulseView.translatesAutoresizingMaskIntoConstraints = false
         step2PulseView.isHidden = true
         
-        step2Circle.backgroundColor = .ddGray300
+        step2Circle.backgroundColor = .ppGray300
         step2Circle.layer.cornerRadius = 12
         stepIndicatorContainer.addSubview(step2Circle)
         step2Circle.translatesAutoresizingMaskIntoConstraints = false
@@ -174,7 +174,7 @@ extension CustomCameraViewController {
         
         step2TextLabel.text = "배경 촬영"
         step2TextLabel.font = UIFont(name: FontName.pretendardMedium.rawValue, size: 14) ?? UIFont.systemFont(ofSize: 14, weight: .medium)
-        step2TextLabel.textColor = .ddGray400
+        step2TextLabel.textColor = .ppGray300
         step2TextLabel.textAlignment = .center
         stepIndicatorContainer.addSubview(step2TextLabel)
         step2TextLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -202,11 +202,11 @@ extension CustomCameraViewController {
         guard !isStickerCamera else { return }
         
         if isCapturingFront {
-            step1Circle.backgroundColor = .ddAlert
+            step1Circle.backgroundColor = .ppSubPrime
             step1Label.isHidden = false
             step1CheckmarkImageView.isHidden = true
             step1Label.textColor = .white
-            step1TextLabel.textColor = .ddAlert
+            step1TextLabel.textColor = .ppSubPrime
             
             step1PulseView.isHidden = false
             addPulseAnimation(to: step1PulseView)
@@ -214,25 +214,25 @@ extension CustomCameraViewController {
             step2PulseView.isHidden = true
             removePulseAnimation(from: step2PulseView)
             
-            step2Circle.backgroundColor = .ddGray300
+            step2Circle.backgroundColor = .ppGray300
             step2Label.isHidden = false
             step2CheckmarkImageView.isHidden = true
             step2Label.textColor = .white
-            step2TextLabel.textColor = .ddGray400
+            step2TextLabel.textColor = .ppGray300
         } else {
-            step1Circle.backgroundColor = .ddGray300
+            step1Circle.backgroundColor = .ppGray300
             step1Label.isHidden = true
             step1CheckmarkImageView.isHidden = false
-            step1TextLabel.textColor = .ddGray400
+            step1TextLabel.textColor = .ppGray300
             
             step1PulseView.isHidden = true
             removePulseAnimation(from: step1PulseView)
             
-            step2Circle.backgroundColor = .ddAlert
+            step2Circle.backgroundColor = .ppSubPrime
             step2Label.isHidden = false
             step2CheckmarkImageView.isHidden = true
             step2Label.textColor = .white
-            step2TextLabel.textColor = .ddAlert
+            step2TextLabel.textColor = .ppSubPrime
             
             step2PulseView.isHidden = false
             addPulseAnimation(to: step2PulseView)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Caption/Views/CaptionView.swift
@@ -47,7 +47,7 @@ struct CaptionView: View {
                                 UIPageControl.appearance().pageIndicatorTintColor = UIColor(Color.ppPrime50)
                             }
                         }
-                        .frame(height: max(470 - keyboard.keyboardHeight, 366))
+                        .frame(maxHeight: 470)
                         .animation(.easeInOut(duration: 0.3), value: keyboard.keyboardHeight)
                         .padding(.vertical, 8)
                         .onTapGesture {
@@ -91,7 +91,9 @@ struct CaptionView: View {
                                 .foregroundStyle(.ppGray200)
                         }
                     }
-                    
+                    Rectangle()
+                        .frame(height: max(0, keyboard.keyboardHeight - 103))
+                        .opacity(0)
                     Spacer()
                     
                     Button {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: View {
             NotConnectedView()
         } else {
             VStack(spacing: 0) {
-                CustomNavigationBar(leadingType: .none, centerType: .logoImage(logoImage: "PicPeekLogo"), trailingType: .timeType(time: viewModel.isShowingATimePost ? "sun.max.fill" : "moon.fill"), navigationColor: .black)
+                CustomNavigationBar(leadingType: .none, centerType: .logoImage(logoImage: "PicPeekLogo"), trailingType: .none, navigationColor: .black)
                     .padding(.horizontal, 26)
                     .onTapGesture {
                         viewModel.isShowStickerSheet = false

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -276,7 +276,3 @@ struct HomeView: View {
         }
     }
 }
-
-#Preview {
-    HomeView(viewModel: HomeViewModel())
-}

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -31,7 +31,7 @@ struct HomeView: View {
                 
                 if !viewModel.isShowStickerSheet {
                     CustomSegmentedControl(items: ArchiveSegment.allCases, selectedItem: $viewModel.selectedPostType, titleProvider: { $0.rawValue })
-                        .padding(.top, 33)
+                        .padding(.top, 27)
                 }
                 
                 ZStack(alignment: .bottom) {
@@ -175,7 +175,7 @@ struct HomeView: View {
                     Spacer()
                 }
                 .padding(.vertical, 22)
-                .padding(.bottom, 12)
+                .padding(.bottom, 24)
                 .background {
                     Rectangle()
                         .foregroundStyle(.ppGray200)

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/HomeEmptyView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/HomeEmptyView.swift
@@ -17,6 +17,7 @@ struct HomeEmptyView: View {
                 .overlay {
                     VStack {
                         Image("HomeEmptyView")
+                            .padding(.top, selectedPostType == ArchiveSegment.partnerArchive ?  0 : 2 )
                         if selectedPostType == ArchiveSegment.partnerArchive {
                             Text("가족이 아직 사진을 올리지 않았어요.")
                                 .font(.subtitleSemiBold16)
@@ -38,7 +39,7 @@ struct HomeEmptyView: View {
                                     .foregroundStyle(.ppGray700)
                             }
                             .font(.subtitleSemiBold16)
-                            .padding(.top, 1)
+                            .padding(.top, 2)
                         }
                     }
                 }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
@@ -73,6 +73,7 @@ struct StickerSheetView: View {
                     categoryKey: gridService.selectedCategory.assetKey,
                     role: UserPairingStore.shared.myRole
                 )
+                .hapticFeedback(.heavy)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .principal) {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/StickerSheetView.swift
@@ -106,6 +106,7 @@ struct StickerSheetView: View {
                                 .font(.captionRegular13)
                                 .foregroundColor(.ppWhite)
                         }
+                        .hapticFeedback(.light)
                     }
                 }
             }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
@@ -159,6 +159,10 @@ struct TabItemView: View {
         .padding(.horizontal, 20)
         .task(id: postId) {
             if let postId = postId {
+                viewModel.frontStickers = []
+                viewModel.backStickers = []
+                viewModel.selectedStickerID = nil
+                
                 viewModel.postId = postId
                 viewModel.postImageType = postImageType
                 await viewModel.fetchStickers()

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/SubViews/TabItemView.swift
@@ -159,13 +159,15 @@ struct TabItemView: View {
         .padding(.horizontal, 20)
         .task(id: postId) {
             if let postId = postId {
-                viewModel.frontStickers = []
-                viewModel.backStickers = []
-                viewModel.selectedStickerID = nil
-                
-                viewModel.postId = postId
+                if viewModel.postId != postId {
+                    viewModel.frontStickers = []
+                    viewModel.backStickers = []
+                    viewModel.selectedStickerID = nil
+                    
+                    viewModel.postId = postId
+                    await viewModel.fetchStickers()
+                }
                 viewModel.postImageType = postImageType
-                await viewModel.fetchStickers()
             }
         }
     }

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/ViewModels/StickerViewModel.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/ViewModels/StickerViewModel.swift
@@ -99,7 +99,7 @@ final class StickerViewModel: ObservableObject {
                 selectedStickerID = newSticker.id
             }
         }
-        selectedStickerID = newSticker.id
+        //selectedStickerID = newSticker.id
         isStickerAttached = true
     }
     

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/ImageView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/ImageView.swift
@@ -12,7 +12,7 @@ struct ImageView: View {
     let urlString: String
     @Binding var isEditing: Bool
     @ObservedObject var viewModel: StickerViewModel
-    @Binding var isZooming: Bool  // @Environment 대신 Binding 사용
+    @Binding var isZooming: Bool
     @Binding var isShowDetail: Bool
     @State private var loadFailed: Bool = false
     let isFront: Bool
@@ -22,8 +22,8 @@ struct ImageView: View {
     }
     
     private var stickers: Binding<[AttachedSticker]> {
-            isFront ? $viewModel.frontStickers : $viewModel.backStickers
-        }
+        isFront ? $viewModel.frontStickers : $viewModel.backStickers
+    }
     
     var body: some View {
         ZStack {

--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/PostContentsView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Post/Views/SubViews/PostContentsView.swift
@@ -18,7 +18,7 @@ struct PostContentsView: View {
     @Binding var isShowDetail: Bool
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             TabView(selection: $isFrontOrBack) {
                 VStack(spacing: 0) {
                     GeometryReader {
@@ -29,10 +29,6 @@ struct PostContentsView: View {
                             .pinchZoom(isZooming: $isZooming, isShowDetail: isShowDetail)
                     }
                     .frame(height: isShowDetail ? 524 : 470)
-                    
-                    Rectangle()
-                        .frame(height: isShowDetail ? 0 : 40)
-                        .foregroundStyle(.ppWhite)
                 }
                 .tag(0)
                 .padding(.horizontal, isShowDetail ? 0 : 20)
@@ -46,27 +42,12 @@ struct PostContentsView: View {
                             .pinchZoom(isZooming: $isZooming, isShowDetail: isShowDetail)
                     }
                     .frame(height: isShowDetail ? 524 : 470)
-                    
-                    Rectangle()
-                        .frame(height: isShowDetail ? 0 : 40)
-                        .foregroundStyle(.ppWhite)
                 }
                 .tag(1)
                 .padding(.horizontal, isShowDetail ? 0 : 20)
             }
-            .tabViewStyle(.page(indexDisplayMode: isShowDetail ? .never : .always))
-            .frame(maxHeight: isShowDetail ? 524 : 510)
-            
-            VStack(spacing: 4) {
-                Text(isShowDetail ? "" : post.caption)
-                    .font(.bodyRegular16)
-                    .foregroundStyle(.ppBlack)
-                
-                Text(isShowDetail ? "" : DateUtils.relativeTimeString(from: post.createdAt.dateValue()))
-                    .font(.captionRegular13)
-                    .foregroundStyle(.ppGray500)
-            }
-            .padding(.bottom, isShowDetail ? 0 : 50)
+            .tabViewStyle(.page(indexDisplayMode: isShowDetail ? .never : .never))
+            .frame(maxHeight: isShowDetail ? 524 : 470)
             
             if isShowDetail {
                 HStack(spacing: 7) {
@@ -77,10 +58,32 @@ struct PostContentsView: View {
                         .frame(width: 7, height: 7)
                         .foregroundStyle(isFrontOrBack == 1 ? .ppWhite : .ppWhite.opacity(0.3))
                 }
+                .padding(.top, 22)
+            } else {
+                HStack(spacing: 7) {
+                    Circle()
+                        .frame(width: 7, height: 7)
+                        .foregroundStyle(isFrontOrBack == 0 ? .ppPrime : .ppPrime.opacity(0.3))
+                    Circle()
+                        .frame(width: 7, height: 7)
+                        .foregroundStyle(isFrontOrBack == 1 ? .ppPrime : .ppPrime.opacity(0.3))
+                }
+                .padding(.top, 12)
             }
+            
+            VStack(spacing: 4) {
+                Text(isShowDetail ? "" : post.caption)
+                    .font(.bodyRegular16)
+                    .foregroundStyle(.ppBlack)
+                
+                Text(isShowDetail ? "" : DateUtils.relativeTimeString(from: post.createdAt.dateValue()))
+                    .font(.captionRegular13)
+                    .foregroundStyle(.ppGray500)
+            }
+            .padding(.top, 20)
             
             Spacer()
         }
-        .padding(.top, 44)
+        .padding(.top, isShowDetail ? 44 : 70)
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #359 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 카메라 스텝 인디케이터 색상 변경 - ppSubPrime

- 홉 엠티뷰 전체 프레임 설정 (텍스트 두께 때문에 가족사진/내사진 엠티뷰의 캐릭터 위치가 조금 다름)

- 캡션뷰 이미지 최소 크기 좀 더 줄이기 (크기를 정해놔서, 키보드 추천 단어 때문에 캡션 입력창이 가려짐)

- 상세뷰 콘텐츠 위치 패딩값 조절

- 홈뷰 스티커 깜빡 해결

- 낮/밤 아이콘 그냥 삭제하기

- (시간나면!! 우선순위 최하!) 스티커를 게시물에 넣을때, 스티커 올린 후 체크박스 누를 때 햅틱?
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2e49e383-7bef-4f7b-9e98-18748be2241c" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0d48549c-f0c6-4de6-a693-9231c0001ef9" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f55e271a-be87-4753-9ae6-461bceffe174" />

https://github.com/user-attachments/assets/bb4cec3d-aa2a-4624-85c2-5a1a626c6f6c


https://github.com/user-attachments/assets/20ca82bd-b3b7-466e-9ba2-f4f6009f88e6



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 스티커시트뷰에서 picker는 햅틱 적용이 안되더라구요

---

