### PR TITLE
fix: #372 스티커 편집 시 전후면 사진 탭 넘어가지 않게 설정

### DIFF
--- a/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
+++ b/DonDog-iOS/DonDog-iOS/Presentation/Features/Home/Views/HomeView.swift
@@ -36,19 +36,33 @@ struct HomeView: View {
                 
                 ZStack(alignment: .bottom) {
                     TabView(selection: $viewModel.currentIndex) {
-                        if viewModel.isUploadingLocalImage, viewModel.selectedPostType == .myArchive, let frontImage = viewModel.localFrontImage, let backImage = viewModel.localBackImage {
-                            Group {
-                                TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .local(frontImage), tag: 0, postId: nil, isShowGradient: !viewModel.isLoading)
-                                TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .local(backImage), tag: 1, postId: nil, isShowGradient: !viewModel.isLoading)
-                            }
-                        } else if let post = viewModel.currentPost, let frontURL = post.frontImageURL, let backURL = post.backImageURL {
-                            Group {
-                                TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .remote(frontURL), tag: 0, postId: post.postId, isShowGradient: !viewModel.isLoading)
-                                TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .remote(backURL), tag: 1, postId: post.postId, isShowGradient: !viewModel.isLoading)
-                            }
+                        if viewModel.isShowStickerSheet {
+                            TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: {
+                                if let frontImage = viewModel.localFrontImage, let backImage = viewModel.localBackImage {
+                                    return viewModel.currentIndex == 0 ? .local(frontImage) : .local(backImage)
+                                } else if let post = viewModel.currentPost,
+                                          let frontURL = post.frontImageURL, let backURL = post.backImageURL {
+                                    return viewModel.currentIndex == 0 ? .remote(frontURL) : .remote(backURL)
+                                } else {
+                                    return .local(UIImage())
+                                }
+                            }(), tag: viewModel.currentIndex, postId: nil, isShowGradient: !viewModel.isLoading)
+                            .tag(viewModel.currentIndex)
                         } else {
-                            HomeEmptyView(selectedPostType: viewModel.selectedPostType)
-                                .tag(0)
+                            if viewModel.isUploadingLocalImage, viewModel.selectedPostType == .myArchive, let frontImage = viewModel.localFrontImage, let backImage = viewModel.localBackImage {
+                                Group {
+                                    TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .local(frontImage), tag: 0, postId: nil, isShowGradient: !viewModel.isLoading)
+                                    TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .local(backImage), tag: 1, postId: nil, isShowGradient: !viewModel.isLoading)
+                                }
+                            } else if let post = viewModel.currentPost, let frontURL = post.frontImageURL, let backURL = post.backImageURL {
+                                Group {
+                                    TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .remote(frontURL), tag: 0, postId: post.postId, isShowGradient: !viewModel.isLoading)
+                                    TabItemView(viewModel: stickerViewModel, isEditing: $viewModel.isShowStickerSheet, imageSource: .remote(backURL), tag: 1, postId: post.postId, isShowGradient: !viewModel.isLoading)
+                                }
+                            } else {
+                                HomeEmptyView(selectedPostType: viewModel.selectedPostType)
+                                    .tag(0)
+                            }
                         }
                     }
                     .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
@@ -142,7 +156,7 @@ struct HomeView: View {
                     Spacer()
                     Button {
                         cameraViewModel.resetCameraState()
-                        viewModel.checkAndShowCamera() 
+                        viewModel.checkAndShowCamera()
                     } label: {
                         Circle()
                             .foregroundColor(.ppWhite)
@@ -209,11 +223,11 @@ struct HomeView: View {
                         },
                         gridService: stickerGridService
                     )
-                    .presentationDetents([.height(317)])
-                    .presentationBackgroundInteraction(.enabled)
-                    .presentationDragIndicator(.hidden)
-                    .interactiveDismissDisabled(true)
-
+                        .presentationDetents([.height(317)])
+                        .presentationBackgroundInteraction(.enabled)
+                        .presentationDragIndicator(.hidden)
+                        .interactiveDismissDisabled(true)
+                    
                     if #available(iOS 17.0, *) {
                         content
                             .presentationBackground(Color.ppRealBlack.opacity(0.95))


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #372 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 스티커 편집 시 전후면 사진 탭 넘어가지 않게 설정

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 두 손가락으로 드래그하는 걸 SwiftUI에서 따로 감지를 못하기도 하고, 이걸 막으려면 스티커에 적용되는 제스쳐까지 막아야 해서 이전 방식처럼 스티커 편집 시에는 탭뷰가 아니라 한 이미지만 그려지게 수정했습니다. 오류 시의 뷰는 임시 처리했습니다.
- 머지되면 각 쇼케이스용 브랜치로 가져가서 적용해주시면 좋을 것 같습니다.